### PR TITLE
회원 email 정보 수정 & 첫 가입 시 GUEST 권한 부여

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,10 +44,10 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
     // MYSQL
-    //implementation 'com.mysql:mysql-connector-j:9.1.0'
+    implementation 'com.mysql:mysql-connector-j:9.1.0'
 
     // H2
-    runtimeOnly 'com.h2database:h2'
+    //runtimeOnly 'com.h2database:h2'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/moongeul/backend/api/member/service/MemeberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemeberService.java
@@ -23,7 +23,6 @@ import org.springframework.web.client.RestTemplate;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -51,13 +50,14 @@ public class MemeberService {
 
         // 2. 사용자 정보 추출
         String socialId = (String) userInfo.get("sub");
+        String email = (String) userInfo.get("email");
         String name = (String) userInfo.get("name");
         String picture = (String) userInfo.get("picture");
 
         // 3. DB 처리 (회원가입 또는 로그인)
         Member member = memberRepository.findBySocialId(socialId)
                 .map(entity -> entity.update(name, picture)) // 이미 있으면 정보 업데이트
-                .orElseGet(() -> signUp(socialId, name, picture)); // 없으면 신규 회원가입
+                .orElseGet(() -> signUp(socialId, email, name, picture)); // 없으면 신규 회원가입
 
         // 4. 자체 JWT 토큰 생성 및 반환
         JwtTokenDTO jwtToken = jwtTokenProvider.generateToken(member);
@@ -71,15 +71,15 @@ public class MemeberService {
     }
 
     // 신규 회원가입 처리 로직 (DB 저장)
-    private Member signUp(String socialId, String name, String picture) {
+    private Member signUp(String socialId, String email, String name, String picture) {
         Member newUser = Member.builder()
-                .email(UUID.randomUUID() + "@socialUser.com")
+                .email(email)
                 .name(name)
                 .profileImage(picture)
                 .password("OAuth Password") // 임시 패스워드
                 .socialId(socialId) // 예시 사용자명 생성
                 .socialType("google")
-                .role(Role.USER)
+                .role(Role.GUEST) // 이후 필요 정보 모두 입력 시 USER 로 승격
                 .build();
         return memberRepository.save(newUser);
     }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #4

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 회원 email 정보: 구글로 소셜 로그인할 경우 UUID를 통한 email 생성이 아닌 사용자의 구글 email을 가져왔습니다. (향후 카카오 로그인에서 email을 가져올 수 없을 경우에는 UUID를 사용하려고 합니다)
- 권한 설정: 첫 가입 시, 권한은 GUEST를 부여하였습니다. (닉네임&취향설정온보딩 개발 이후 USER로 승격하는 코드를 개발하고자 합니다)
- build.gradle -> h2 비활성화, mysql 활성화 했습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->