### PR TITLE
카카오 소셜 로그인 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -25,18 +25,36 @@ public class MemberController {
     private final MemberService memberService;
 
     @Operation(
-            summary = "로그인 API",
-            description = "구글 인가코드을 통해 사용자의 정보를 등록 및 토큰 + 역할을 발급합니다. (ROLE -> 처음사용자 : GUEST, 일반사용자 : USER, 관리자 : ADMIN)"
+            summary = "구글 로그인 API",
+            description = "구글 인가코드을 통해 사용자의 정보를 등록 및 토큰 + 역할을 발급합니다. (ROLE -> 처음사용자 : ROLE_GUEST, 일반사용자 : ROLE_USER, 관리자 : ROLE_ADMIN)"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "구글 엑세스토큰이 입력되지 않았습니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 엑세스토큰 입니다.")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "인가코드가 입력되지 않았습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 인가코드 입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "로그인 서버 오류 발생")
     })
-    @PostMapping("/login")
+    @PostMapping("/google/login")
     public ResponseEntity<ApiResponse<LoginResponseDTO>> loginWithGoogle(@Valid @RequestBody LoginRequestDTO loginRequestDTO) {
 
         LoginResponseDTO response = memberService.loginWithGoogle(loginRequestDTO.getCode());
+        return ApiResponse.success(SuccessStatus.SEND_LOGIN_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "카카오 로그인 API",
+            description = "카카오 인가코드을 통해 사용자의 정보를 등록 및 토큰 + 역할을 발급합니다. (ROLE -> 처음사용자 : ROLE_GUEST, 일반사용자 : ROLE_USER, 관리자 : ROLE_ADMIN)"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "인가코드가 입력되지 않았습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 인가코드 입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "로그인 서버 오류 발생")
+    })
+    @PostMapping("/kakao/login")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> loginWithKakao(@Valid @RequestBody LoginRequestDTO loginRequestDTO) {
+
+        LoginResponseDTO response = memberService.loginWithKakao(loginRequestDTO.getCode());
         return ApiResponse.success(SuccessStatus.SEND_LOGIN_SUCCESS, response);
     }
 

--- a/src/main/java/com/moongeul/backend/api/member/dto/AccessTokenResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/AccessTokenResponseDTO.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class GoogleTokenResponseDTO {
+public class AccessTokenResponseDTO {
 
     // JSON의 access_token 필드를 이 변수에 매핑
     @JsonProperty("access_token")

--- a/src/main/java/com/moongeul/backend/api/member/dto/KakaoInfoResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/KakaoInfoResponseDTO.java
@@ -1,0 +1,40 @@
+package com.moongeul.backend.api.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true) // JSON 에는 있지만 DTO 에 없는 필드 무시
+public class KakaoInfoResponseDTO {
+
+    private Long id; //회원번호
+
+    //카카오 계정 정보
+    @JsonProperty("kakao_account")
+    public KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoAccount {
+
+        //사용자 프로필 정보
+        @JsonProperty("profile")
+        public Profile profile;
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Profile{
+            @JsonProperty("nickname")
+            private String name;
+
+            @JsonProperty("profile_image_url")
+            private String picture;
+        }
+    }
+
+}

--- a/src/main/java/com/moongeul/backend/api/member/dto/LoginRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/LoginRequestDTO.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 public class LoginRequestDTO {
 
-    @NotBlank(message = "구글 엑세스토큰이 입력되지 않았습니다.")
+    @NotBlank(message = "인가코드가 입력되지 않았습니다.")
     private String code; // 인가코드
 }

--- a/src/main/java/com/moongeul/backend/api/member/service/GoogleOAuthService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/GoogleOAuthService.java
@@ -1,0 +1,100 @@
+package com.moongeul.backend.api.member.service;
+
+import com.moongeul.backend.api.member.dto.GoogleInfoResponseDTO;
+import com.moongeul.backend.api.member.dto.AccessTokenResponseDTO;
+import com.moongeul.backend.common.exception.BadRequestException;
+import com.moongeul.backend.common.exception.InternalServerException;
+import com.moongeul.backend.common.exception.UnauthorizedException;
+import com.moongeul.backend.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleOAuthService {
+
+    private static final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+    private static final String GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo";
+    private final WebClient webClient;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String clientId;
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String clientSecret;
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String redirectUri;
+
+    // Google 토큰 획득 로직 (WebClient 방식으로 수정 - 비동기 방식 구현)
+    public AccessTokenResponseDTO getGoogleToken(String code) {
+
+        String decodedCode;
+        try {
+            // 인코딩된 code 값(예: %2F)을 원래 값(/)으로 디코딩합니다.
+            decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            // 디코딩 실패 시 원본 코드를 사용하거나, 예외를 다시 던집니다.
+            log.error("URL Decoding Failed, using original code.", e);
+            decodedCode = code;
+        }
+
+        // ... (실제 Google OAuth 2.0 /token 엔드포인트 통신 로직 구현 필요)
+        // HTTP Body에 전송할 파라미터 담기
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", decodedCode);
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("grant_type", "authorization_code"); // 인가 코드를 토큰으로 교환함을 명시
+
+        return webClient.post()
+                .uri(GOOGLE_TOKEN_URL)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(params))
+                .retrieve()
+                .onStatus(status -> status.value() == 401, response -> {
+                    throw new UnauthorizedException(ErrorStatus.AUTH_UNAUTHORIZED.getMessage());
+                })
+                .onStatus(HttpStatusCode::is4xxClientError, response -> {
+                    throw new BadRequestException(ErrorStatus.INVALID_TOKEN_REQUEST.getMessage());
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, response -> {
+                    throw new InternalServerException(ErrorStatus.SERVER_ERROR.getMessage());
+                })
+                .bodyToMono(AccessTokenResponseDTO.class)
+                .block();
+    }
+
+    // Google 사용자 정보 획득 로직 (생략: RestTemplate을 사용해 GET 요청)
+    public GoogleInfoResponseDTO getGoogleUserInfo(String googleAccessToken) {
+
+        return webClient.get()
+                .uri(GOOGLE_USERINFO_URL)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + googleAccessToken)
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(status -> status.value() == 401, response -> {
+                    throw new UnauthorizedException(ErrorStatus.AUTH_UNAUTHORIZED.getMessage());
+                })
+                .onStatus(HttpStatusCode::is4xxClientError, response -> {
+                    throw new BadRequestException(ErrorStatus.INVALID_INFO_REQUEST.getMessage());
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, response -> {
+                    throw new InternalServerException(ErrorStatus.SERVER_ERROR.getMessage());
+                })
+                .bodyToMono(GoogleInfoResponseDTO.class)
+                .block(); // 동기 방식으로 결과 대기
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/member/service/KakaoOAuthService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/KakaoOAuthService.java
@@ -1,7 +1,7 @@
 package com.moongeul.backend.api.member.service;
 
-import com.moongeul.backend.api.member.dto.GoogleInfoResponseDTO;
-import com.moongeul.backend.api.member.dto.GoogleTokenResponseDTO;
+import com.moongeul.backend.api.member.dto.AccessTokenResponseDTO;
+import com.moongeul.backend.api.member.dto.KakaoInfoResponseDTO;
 import com.moongeul.backend.common.exception.BadRequestException;
 import com.moongeul.backend.common.exception.InternalServerException;
 import com.moongeul.backend.common.exception.UnauthorizedException;
@@ -18,54 +18,41 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class OAuthService {
+public class KakaoOAuthService {
 
-    private static final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
-    private static final String GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo";
+    private static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String KAKAO_USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
     private final WebClient webClient;
 
-    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String clientId;
-    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
     private String clientSecret;
-    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
     private String redirectUri;
 
-    // Google 토큰 획득 로직 (WebClient 방식으로 수정 - 비동기 방식 구현)
-    public GoogleTokenResponseDTO getGoogleToken(String code) {
+    // Kakao 토큰 획득 로직
+    public AccessTokenResponseDTO getKakaoToken(String code){
 
-        String decodedCode;
-        try {
-            // 인코딩된 code 값(예: %2F)을 원래 값(/)으로 디코딩합니다.
-            decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
-        } catch (Exception e) {
-            // 디코딩 실패 시 원본 코드를 사용하거나, 예외를 다시 던집니다.
-            log.error("URL Decoding Failed, using original code.", e);
-            decodedCode = code;
-        }
-
-        // ... (실제 Google OAuth 2.0 /token 엔드포인트 통신 로직 구현 필요)
-        // HTTP Body에 전송할 파라미터 담기
+        // HTTP Body 생성
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("code", decodedCode);
+        params.add("grant_type", "authorization_code");
         params.add("client_id", clientId);
         params.add("client_secret", clientSecret);
         params.add("redirect_uri", redirectUri);
-        params.add("grant_type", "authorization_code"); // 인가 코드를 토큰으로 교환함을 명시
+        params.add("code", code);
 
         return webClient.post()
-                .uri(GOOGLE_TOKEN_URL)
+                .uri(KAKAO_TOKEN_URL)
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(BodyInserters.fromFormData(params))
                 .retrieve()
                 .onStatus(status -> status.value() == 401, response -> {
-                    throw new UnauthorizedException(ErrorStatus.GOOGLE_AUTH_UNAUTHORIZED.getMessage());
+                    throw new UnauthorizedException(ErrorStatus.AUTH_UNAUTHORIZED.getMessage());
                 })
                 .onStatus(HttpStatusCode::is4xxClientError, response -> {
                     throw new BadRequestException(ErrorStatus.INVALID_TOKEN_REQUEST.getMessage());
@@ -73,20 +60,20 @@ public class OAuthService {
                 .onStatus(HttpStatusCode::is5xxServerError, response -> {
                     throw new InternalServerException(ErrorStatus.SERVER_ERROR.getMessage());
                 })
-                .bodyToMono(GoogleTokenResponseDTO.class)
+                .bodyToMono(AccessTokenResponseDTO.class)
                 .block();
     }
 
-    // Google 사용자 정보 획득 로직 (생략: RestTemplate을 사용해 GET 요청)
-    public GoogleInfoResponseDTO getGoogleUserInfo(String googleAccessToken) {
+    // Kakao 사용자 정보 획득 로직
+    public KakaoInfoResponseDTO getKakaoUserInfo(String kakaoAccessToken){
 
         return webClient.get()
-                .uri(GOOGLE_USERINFO_URL)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + googleAccessToken)
+                .uri(KAKAO_USERINFO_URL)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + kakaoAccessToken)
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .onStatus(status -> status.value() == 401, response -> {
-                    throw new UnauthorizedException(ErrorStatus.GOOGLE_AUTH_UNAUTHORIZED.getMessage());
+                    throw new UnauthorizedException(ErrorStatus.AUTH_UNAUTHORIZED.getMessage());
                 })
                 .onStatus(HttpStatusCode::is4xxClientError, response -> {
                     throw new BadRequestException(ErrorStatus.INVALID_INFO_REQUEST.getMessage());
@@ -94,7 +81,7 @@ public class OAuthService {
                 .onStatus(HttpStatusCode::is5xxServerError, response -> {
                     throw new InternalServerException(ErrorStatus.SERVER_ERROR.getMessage());
                 })
-                .bodyToMono(GoogleInfoResponseDTO.class)
+                .bodyToMono(KakaoInfoResponseDTO.class)
                 .block(); // 동기 방식으로 결과 대기
     }
 }

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -1,12 +1,9 @@
 package com.moongeul.backend.api.member.service;
 
-import com.moongeul.backend.api.member.dto.GoogleInfoResponseDTO;
-import com.moongeul.backend.api.member.dto.GoogleTokenResponseDTO;
-import com.moongeul.backend.api.member.dto.UserInfoDTO;
+import com.moongeul.backend.api.member.dto.*;
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.entity.Role;
 import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
-import com.moongeul.backend.api.member.dto.LoginResponseDTO;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.common.config.jwt.JwtTokenProvider;
 import com.moongeul.backend.common.exception.NotFoundException;
@@ -16,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -23,26 +22,57 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
-    private final OAuthService oAuthService;
+    private final GoogleOAuthService googleOAuthService;
+    private final KakaoOAuthService kakaoOAuthService;
 
     // 인가코드 받아 JWT로 교환 및 회원가입/로그인 처리
     @Transactional
     public LoginResponseDTO loginWithGoogle(String code){
 
         // 1. 인가 코드로 Google Access Token 및 사용자 정보 획득
-        GoogleTokenResponseDTO tokenResponse = oAuthService.getGoogleToken(code);
-        GoogleInfoResponseDTO userInfo = oAuthService.getGoogleUserInfo(tokenResponse.getAccessToken());
+        AccessTokenResponseDTO tokenDTO = googleOAuthService.getGoogleToken(code);
+        GoogleInfoResponseDTO userInfo = googleOAuthService.getGoogleUserInfo(tokenDTO.getAccessToken());
 
         // 2. 사용자 정보 추출
         String socialId = userInfo.getId();
         String email = userInfo.getEmail();
         String name = userInfo.getName();
         String picture = userInfo.getPicture();
+        String socialType = "google";
 
         // 3. DB 처리 (회원가입 또는 로그인)
         Member member = memberRepository.findBySocialId(socialId)
                 .map(entity -> entity.update(name, picture)) // 이미 있으면 정보 업데이트
-                .orElseGet(() -> signUp(socialId, email, name, picture)); // 없으면 신규 회원가입
+                .orElseGet(() -> signUp(socialId, email, name, picture, socialType)); // 없으면 신규 회원가입
+
+        // 4. 자체 JWT 토큰 생성 및 반환
+        JwtTokenDTO jwtToken = jwtTokenProvider.generateToken(member);
+        member.updateRefreshToken(jwtToken.getRefreshToken()); // 생성된 refreshToken DB 저장
+
+        return LoginResponseDTO.builder()
+                .role(member.getAuthorityKey())
+                .accessToken(jwtToken.getAccessToken())
+                .refreshToken(jwtToken.getRefreshToken())
+                .build();
+    }
+
+    @Transactional
+    public LoginResponseDTO loginWithKakao(String code){
+
+        AccessTokenResponseDTO tokenDTO = kakaoOAuthService.getKakaoToken(code);
+        KakaoInfoResponseDTO userInfo = kakaoOAuthService.getKakaoUserInfo(tokenDTO.getAccessToken());
+
+        // 2. 사용자 정보 추출
+        String socialId = userInfo.getId().toString();
+        String name = userInfo.getKakaoAccount().getProfile().getName();
+        String email = UUID.randomUUID() + "@socialUser.com";
+        String picture = userInfo.getKakaoAccount().getProfile().getPicture();
+        String socialType = "kakao";
+
+        // 3. DB 처리 (회원가입 또는 로그인)
+        Member member = memberRepository.findBySocialId(socialId)
+                .map(entity -> entity.update(name, picture)) // 이미 있으면 정보 업데이트
+                .orElseGet(() -> signUp(socialId, email, name, picture, socialType)); // 없으면 신규 회원가입
 
         // 4. 자체 JWT 토큰 생성 및 반환
         JwtTokenDTO jwtToken = jwtTokenProvider.generateToken(member);
@@ -56,14 +86,14 @@ public class MemberService {
     }
 
     // 신규 회원가입 처리 로직 (DB 저장)
-    private Member signUp(String socialId, String email, String name, String picture) {
+    private Member signUp(String socialId, String email, String name, String picture, String socialType) {
         Member newUser = Member.builder()
                 .email(email)
                 .name(name)
                 .profileImage(picture)
                 .password("OAuth Password") // 임시 패스워드
                 .socialId(socialId) // 예시 사용자명 생성
-                .socialType("google")
+                .socialType(socialType)
                 .role(Role.GUEST) // 이후 필요 정보 모두 입력 시 USER 로 승격
                 .build();
         return memberRepository.save(newUser);

--- a/src/main/java/com/moongeul/backend/common/config/oauth2/SecurityConfig.java
+++ b/src/main/java/com/moongeul/backend/common/config/oauth2/SecurityConfig.java
@@ -21,8 +21,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
-    //private final PrincipalOauth2UserService principalOauth2UserService;
-    //private final AuthenticationSuccessHandler OAuth2LoginSuccessHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -33,7 +31,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 무상태 설정
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable())) //h2-console 화면 깨짐 방지(iframe 렌더링 오류)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/api/v2/member/login", "/h2-console/**").permitAll()
+                        .requestMatchers("/", "/api/v2/member/google/login", "/api/v2/member/kakao/login", "/h2-console/**").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/api-doc/**", "/swagger-ui/**").permitAll()
                         .anyRequest().authenticated()
                 );
@@ -44,14 +42,6 @@ public class SecurityConfig {
                 new JwtAuthenticationFilter(jwtTokenProvider), // JwtTokenProvider 주입
                 UsernamePasswordAuthenticationFilter.class // UsernamePasswordAuthenticationFilter 이전에 실행
         );
-
-//        // OAuth2 로그인 설정
-//        http
-//                .oauth2Login((oauth2) -> oauth2
-//                        .userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint
-//                                .userService(principalOauth2UserService)) // 후처리 로직 연결
-//                        .successHandler(OAuth2LoginSuccessHandler)
-//                );
 
         return http.build();
     }

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -15,13 +15,14 @@ public enum ErrorStatus {
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값이 입력되지 않았습니다."),
     USER_ALREADY_EXISTS_EXCEPTION(HttpStatus.BAD_REQUEST,"이미 존재하는 사용자입니다."),
     MISSING_GOOGLE_ACCESSTOKEN(HttpStatus.BAD_REQUEST, "구글 엑세스토큰이 입력되지 않았습니다."),
+    MISSING_KAKAO_ACCESSTOKEN(HttpStatus.BAD_REQUEST, "카카오 엑세스토큰이 입력되지 않았습니다."),
     INVALID_TOKEN_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 토큰 요청입니다."),
     INVALID_INFO_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 로그인 인증 요청입니다."),
 
     /**
      * 401 UNAUTHORIZED
      */
-    GOOGLE_AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "구글 인증에 실패했습니다.(토큰 문제)"),
+    AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "유효하지 않은 인가코드 입니다."),
 
     /**
      * 404 NOT_FOUND


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #9 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 카카오 소셜 로그인을 구현하였습니다.
- 클라이언트에서 인가코드(code) 카카오 로그인 API에 전달하면 자체 JWT 토큰을 발급하여 role, accessToken, refreshToken을 발급하여 response합니다.
- 카카오/구글 두 가지 소셜 로그인이 존재하여 API를 분리하였습니다.
  - 기존: `/api/v2/member/login`
  - 변경: (카카오) `/api/v2/member/kakao/login` / (구글) `/api/v2/member/google/login`
- 처리 로직인 서비스 코드 역시 `KakaoOAuthService.java` , `GoogleOAuthService.java` 로 분리하였습니다.

+) 추가
- 프론트엔드의 개발 테스트를 위하여 임시로 서버의 redirect_uri를 `localhost:3000/redirect` 로 지정하였습니다.
- 이후 서비스 배포 시, 배포 uri 로 수정해야합니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- [카카오 로그인 API 공식문서](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api)