### PR TITLE
[REFAC] 로그인 처리 코드 서버 로그 찍기

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/service/GoogleOAuthService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/GoogleOAuthService.java
@@ -2,10 +2,7 @@ package com.moongeul.backend.api.member.service;
 
 import com.moongeul.backend.api.member.dto.GoogleInfoResponseDTO;
 import com.moongeul.backend.api.member.dto.AccessTokenResponseDTO;
-import com.moongeul.backend.common.exception.BadRequestException;
-import com.moongeul.backend.common.exception.InternalServerException;
-import com.moongeul.backend.common.exception.UnauthorizedException;
-import com.moongeul.backend.common.response.ErrorStatus;
+import com.moongeul.backend.common.config.webclient.WebClientErrorHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,6 +25,7 @@ public class GoogleOAuthService {
 
     private static final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
     private static final String GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo";
+
     private final WebClient webClient;
 
     @Value("${spring.security.oauth2.client.registration.google.client-id}")
@@ -64,15 +62,7 @@ public class GoogleOAuthService {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(BodyInserters.fromFormData(params))
                 .retrieve()
-                .onStatus(status -> status.value() == 401, response -> {
-                    throw new UnauthorizedException(ErrorStatus.AUTH_UNAUTHORIZED.getMessage());
-                })
-                .onStatus(HttpStatusCode::is4xxClientError, response -> {
-                    throw new BadRequestException(ErrorStatus.INVALID_TOKEN_REQUEST.getMessage());
-                })
-                .onStatus(HttpStatusCode::is5xxServerError, response -> {
-                    throw new InternalServerException(ErrorStatus.SERVER_ERROR.getMessage());
-                })
+                .onStatus(HttpStatusCode::isError, res -> WebClientErrorHandler.handleApiError(res, "getGoogleToken"))
                 .bodyToMono(AccessTokenResponseDTO.class)
                 .block();
     }
@@ -85,15 +75,7 @@ public class GoogleOAuthService {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + googleAccessToken)
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
-                .onStatus(status -> status.value() == 401, response -> {
-                    throw new UnauthorizedException(ErrorStatus.AUTH_UNAUTHORIZED.getMessage());
-                })
-                .onStatus(HttpStatusCode::is4xxClientError, response -> {
-                    throw new BadRequestException(ErrorStatus.INVALID_INFO_REQUEST.getMessage());
-                })
-                .onStatus(HttpStatusCode::is5xxServerError, response -> {
-                    throw new InternalServerException(ErrorStatus.SERVER_ERROR.getMessage());
-                })
+                .onStatus(HttpStatusCode::isError, res -> WebClientErrorHandler.handleApiError(res, "getGoogleUserInfo"))
                 .bodyToMono(GoogleInfoResponseDTO.class)
                 .block(); // 동기 방식으로 결과 대기
     }

--- a/src/main/java/com/moongeul/backend/api/member/service/KakaoOAuthService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/KakaoOAuthService.java
@@ -2,10 +2,7 @@ package com.moongeul.backend.api.member.service;
 
 import com.moongeul.backend.api.member.dto.AccessTokenResponseDTO;
 import com.moongeul.backend.api.member.dto.KakaoInfoResponseDTO;
-import com.moongeul.backend.common.exception.BadRequestException;
-import com.moongeul.backend.common.exception.InternalServerException;
-import com.moongeul.backend.common.exception.UnauthorizedException;
-import com.moongeul.backend.common.response.ErrorStatus;
+import com.moongeul.backend.common.config.webclient.WebClientErrorHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -51,15 +48,7 @@ public class KakaoOAuthService {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(BodyInserters.fromFormData(params))
                 .retrieve()
-                .onStatus(status -> status.value() == 401, response -> {
-                    throw new UnauthorizedException(ErrorStatus.AUTH_UNAUTHORIZED.getMessage());
-                })
-                .onStatus(HttpStatusCode::is4xxClientError, response -> {
-                    throw new BadRequestException(ErrorStatus.INVALID_TOKEN_REQUEST.getMessage());
-                })
-                .onStatus(HttpStatusCode::is5xxServerError, response -> {
-                    throw new InternalServerException(ErrorStatus.SERVER_ERROR.getMessage());
-                })
+                .onStatus(HttpStatusCode::isError, res -> WebClientErrorHandler.handleApiError(res, "getKakaoToken"))
                 .bodyToMono(AccessTokenResponseDTO.class)
                 .block();
     }
@@ -72,15 +61,7 @@ public class KakaoOAuthService {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + kakaoAccessToken)
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
-                .onStatus(status -> status.value() == 401, response -> {
-                    throw new UnauthorizedException(ErrorStatus.AUTH_UNAUTHORIZED.getMessage());
-                })
-                .onStatus(HttpStatusCode::is4xxClientError, response -> {
-                    throw new BadRequestException(ErrorStatus.INVALID_INFO_REQUEST.getMessage());
-                })
-                .onStatus(HttpStatusCode::is5xxServerError, response -> {
-                    throw new InternalServerException(ErrorStatus.SERVER_ERROR.getMessage());
-                })
+                .onStatus(HttpStatusCode::isError, res -> WebClientErrorHandler.handleApiError(res, "getKakaoUserInfo"))
                 .bodyToMono(KakaoInfoResponseDTO.class)
                 .block(); // 동기 방식으로 결과 대기
     }

--- a/src/main/java/com/moongeul/backend/common/config/webclient/WebClientErrorHandler.java
+++ b/src/main/java/com/moongeul/backend/common/config/webclient/WebClientErrorHandler.java
@@ -1,0 +1,29 @@
+package com.moongeul.backend.common.config.webclient;
+
+import com.moongeul.backend.common.exception.BadRequestException;
+import com.moongeul.backend.common.exception.InternalServerException;
+import com.moongeul.backend.common.exception.UnauthorizedException;
+import com.moongeul.backend.common.response.ErrorStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+public class WebClientErrorHandler {
+
+    public static Mono<Throwable> handleApiError(ClientResponse response, String apiName) {
+        return response.bodyToMono(String.class)
+                .defaultIfEmpty("No error body content")
+                .flatMap(errorBody -> {
+                    log.error("[{}] API Error: Status Code: {}, Body: {}", apiName, response.statusCode(), errorBody);
+
+                    if (response.statusCode().value() == 401) {
+                        return Mono.error(new UnauthorizedException(ErrorStatus.AUTH_UNAUTHORIZED.getMessage()));
+                    } else if (response.statusCode().is4xxClientError()) {
+                        return Mono.error(new BadRequestException(ErrorStatus.INVALID_TOKEN_REQUEST.getMessage()));
+                    } else {
+                        return Mono.error(new InternalServerException(ErrorStatus.SERVER_ERROR.getMessage()));
+                    }
+                });
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #17 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
[기존 코드의 문제점]
단순한 예외(4xx, 5xx)만 던지고 외부 API가 제공하는 상세 에러 본문/구체적인 오류(예: 만료된 코드, 잘못된 시크릿 키 등)을 로그로 남기지 않았음

[수정한 코드]
- 에러 응답을 서버 로그에 상세히 남기는 코드를 구현하였습니다.
  - `bodyToMono(String.class)`: 에러가 발생했을 때 서버가 보낸 응답 본문(Error Body)을 읽어옴
  - `defaultIfEmpty(...)`: 만약 응답 바디가 비어있을 경우 발생할 수 있는 오류를 방지하는 안전장치
  - `flatMap`: 읽어온 에러 바디와 상태 코드를 조합하여 로깅(Logging)을 수행하고, 최종적으로 우리 시스템에 정의된 커스텀 예외로 변환

- `WebClientErrorHandler` : WebClient 공통 에러 핸들링을 도입했습니다.
  - 문제: 기존 API의 에러코드는 onStatus 로직이 반복되어 코드가 비대해지고 가독성이 떨어짐
  - 해결: 에러 처리 로직을 별도의 공통 헬퍼 클래스로 분리하고, `onStatus(HttpStatusCode::isError, res -> WebClientErrorHandler.handleApiError(res, "API명"))` 형태로 한 줄 선언하게 개선하였습니다.

[에러 처리 흐름]
1. 감지: WebClient 호출 시 onStatus를 통해 HTTP 에러 상태(4xx, 5xx)를 감지합니다.
2. 기록: log.error를 통해 어떤 API(apiName)에서 어떤 응답(errorBody)이 왔는지 서버 로그에 상세히 남깁니다.
3. 변환: 외부의 상태 코드를 기반으로 서비스 내부 예외(UnauthorizedException 등)로 매핑합니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="1772" height="81" alt="image" src="https://github.com/user-attachments/assets/1f304e24-8a4f-46d1-92f3-01bed8d19f7c" />

```
2025-12-17T16:11:53.280+09:00 ERROR 18708 --- [moongeul] [ctor-http-nio-2] c.m.b.c.c.w.WebClientErrorHandler        : [getKakaoToken] API Error: Status Code: 400 BAD_REQUEST, Body: {"error":"invalid_grant","error_description":"authorization code not found for code=[인가코드]","error_code":"KOE320"}
```
-> 위와 같은 에러 문구가 서버 로그에 찍힘