### PR TITLE
[FEAT] 글쓰기+카테고리 API - 기록 공개, 카테고리 설정 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/category/controller/CategoryController.java
+++ b/src/main/java/com/moongeul/backend/api/category/controller/CategoryController.java
@@ -1,0 +1,58 @@
+package com.moongeul.backend.api.category.controller;
+
+import com.moongeul.backend.api.category.dto.CategoryCreateRequestDTO;
+import com.moongeul.backend.api.category.dto.CategoryListResponseDTO;
+import com.moongeul.backend.api.category.dto.CategoryResponseDTO;
+import com.moongeul.backend.api.category.service.CategoryService;
+import com.moongeul.backend.common.response.ApiResponse;
+import com.moongeul.backend.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Category", description = "Category(카테고리-기록) 관련 API 입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/category")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @Operation(
+            summary = "내 카테고리 전체 조회 API",
+            description = "사용자의 카테고리를 가져오는 API 입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카테고리 전체 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "카테고리명은 필수입니다. (category)"),
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<CategoryListResponseDTO>> getCategory(@AuthenticationPrincipal UserDetails userDetails) {
+
+        CategoryListResponseDTO response = categoryService.getCategory(userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.GET_CATEGORY_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "카테고리 생성 API",
+            description = "기록에 대한 카테고리를 생성하는 API 입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카테고리 생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "카테고리명은 필수입니다. (category)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 카테고리를 찾을 수 없습니다."),
+    })
+    @PostMapping("/create")
+    public ResponseEntity<ApiResponse<CategoryResponseDTO>> createCategory(@AuthenticationPrincipal UserDetails userDetails,
+                                                                           @Valid @RequestBody CategoryCreateRequestDTO categoryCreateRequestDTO) {
+
+        CategoryResponseDTO response = categoryService.createCategory(categoryCreateRequestDTO, userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.CREATE_CATEGORY_SUCCESS, response);
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/category/dto/CategoryCreateRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/category/dto/CategoryCreateRequestDTO.java
@@ -1,0 +1,27 @@
+package com.moongeul.backend.api.category.dto;
+
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.category.entity.Category;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryCreateRequestDTO {
+
+    @NotBlank(message = "카테고리명은 필수입니다")
+    private String category; // 카테고리명
+
+    public Category toEntity(Member member){
+
+        return Category.builder()
+                .title(this.category)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/category/dto/CategoryListResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/category/dto/CategoryListResponseDTO.java
@@ -1,0 +1,17 @@
+package com.moongeul.backend.api.category.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryListResponseDTO {
+
+    private List<CategoryResponseDTO> categoryList; // 카테고리 리스트
+}

--- a/src/main/java/com/moongeul/backend/api/category/dto/CategoryResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/category/dto/CategoryResponseDTO.java
@@ -1,0 +1,16 @@
+package com.moongeul.backend.api.category.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryResponseDTO {
+
+    private Long categoryId; // 카테고리 번호
+    private String title; // 카테고리 제목
+}

--- a/src/main/java/com/moongeul/backend/api/category/entity/Category.java
+++ b/src/main/java/com/moongeul/backend/api/category/entity/Category.java
@@ -1,4 +1,4 @@
-package com.moongeul.backend.api.post.entity;
+package com.moongeul.backend.api.category.entity;
 
 import com.moongeul.backend.api.member.entity.Member;
 import jakarta.persistence.*;
@@ -19,7 +19,7 @@ public class Category {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 카테고리 id
 
-    private String title; // 카테고리 제목
+    private String title; // 카테고리명
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/moongeul/backend/api/category/repository/CategoryRepository.java
+++ b/src/main/java/com/moongeul/backend/api/category/repository/CategoryRepository.java
@@ -1,0 +1,14 @@
+package com.moongeul.backend.api.category.repository;
+
+
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category, Long>  {
+
+    Optional<List<Category>> findByMember(Member member);
+}

--- a/src/main/java/com/moongeul/backend/api/category/service/CategoryService.java
+++ b/src/main/java/com/moongeul/backend/api/category/service/CategoryService.java
@@ -1,0 +1,68 @@
+package com.moongeul.backend.api.category.service;
+
+import com.moongeul.backend.api.category.dto.CategoryCreateRequestDTO;
+import com.moongeul.backend.api.category.dto.CategoryListResponseDTO;
+import com.moongeul.backend.api.category.dto.CategoryResponseDTO;
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.api.category.entity.Category;
+import com.moongeul.backend.api.category.repository.CategoryRepository;
+import com.moongeul.backend.common.exception.NotFoundException;
+import com.moongeul.backend.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+
+    /* 카테고리 생성 */
+    @Transactional
+    public CategoryResponseDTO createCategory(CategoryCreateRequestDTO categoryCreateRequestDTO, String email){
+
+        Member member = getMemberByEmail(email);
+
+        Category newCategory = categoryCreateRequestDTO.toEntity(member);
+        Category savedCategory = categoryRepository.save(newCategory);
+
+        return CategoryResponseDTO.builder()
+                .categoryId(savedCategory.getId())
+                .title(savedCategory.getTitle())
+                .build();
+    }
+
+    /* 내 카테고리 전체 조회 */
+    @Transactional
+    public CategoryListResponseDTO getCategory(String email){
+
+        Member member = getMemberByEmail(email);
+
+        List<Category> categoryList = categoryRepository.findByMember(member)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage()));
+
+        List<CategoryResponseDTO> categoryResponseDTOList = categoryList.stream()
+                .map(category -> CategoryResponseDTO.builder()
+                        .categoryId(category.getId())
+                        .title(category.getTitle())
+                        .build())
+                .toList();
+
+        return CategoryListResponseDTO.builder()
+                .categoryList(categoryResponseDTOList)
+                .build();
+    }
+
+    // 사용자 정보 가져오기 메서드
+    private Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -27,7 +27,7 @@ public class MemberController {
 
     @Operation(
             summary = "구글 로그인 API",
-            description = "구글 인가코드을 통해 사용자의 정보를 등록 및 토큰 + 역할을 발급합니다. (ROLE -> 처음사용자 : ROLE_GUEST, 일반사용자 : ROLE_USER, 관리자 : ROLE_ADMIN)"
+            description = "구글 인가코드을 통해 사용자의 정보를 등록 및 토큰 + 역할을 발급합니다. (ROLE -> 처음사용자 : GUEST, 일반사용자 : USER, 관리자 : ADMIN)"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
@@ -44,7 +44,7 @@ public class MemberController {
 
     @Operation(
             summary = "카카오 로그인 API",
-            description = "카카오 인가코드을 통해 사용자의 정보를 등록 및 토큰 + 역할을 발급합니다. (ROLE -> 처음사용자 : ROLE_GUEST, 일반사용자 : ROLE_USER, 관리자 : ROLE_ADMIN)"
+            description = "카카오 인가코드을 통해 사용자의 정보를 등록 및 토큰 + 역할을 발급합니다. (ROLE -> 처음사용자 : GUEST, 일반사용자 : USER, 관리자 : ADMIN)"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),

--- a/src/main/java/com/moongeul/backend/api/member/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moongeul/backend/api/member/jwt/filter/JwtAuthenticationFilter.java
@@ -41,7 +41,6 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     // Request Header에서 토큰 정보 추출
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
-        log.info("Authorization Header Value: [{}]", bearerToken); // 💡 값 전체 출력 (로그 레벨 info 이상)
 
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
             return bearerToken.substring(7).trim();

--- a/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
+++ b/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
@@ -13,10 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Post", description = "Post(게시글) 관련 API 입니다.")
 @RestController
@@ -30,7 +27,8 @@ public class PostController {
             summary = "글쓰기 API",
             description = "기록(게시글)을 작성하는 글쓰기 API 입니다." +
                     "<br>필수: isbn, readDate / 선택: rating(default = 5.0), page(default = 300), content, quotes" +
-                    "<br>선택 요소의 경우 입력되지 않았을 때 'null'로 전달 바랍니다."
+                    "<br>선택 요소의 경우 입력되지 않았을 때 'null'로 전달 바랍니다." +
+                    "<br><br>[enum] postVisibility -> 전체 공개 : PUBLIC, 팔로워 공개 : FOLLOWERS, 나만보기 : PRIVATE"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "글쓰기 성공"),
@@ -39,7 +37,7 @@ public class PostController {
     })
     @PostMapping("/create")
     public ResponseEntity<ApiResponse<PostCreateResponseDTO>> createPost(@AuthenticationPrincipal UserDetails userDetails,
-                                                        @Valid @RequestBody PostCreateRequestDTO postCreateRequestDTO) {
+                                                                         @Valid @RequestBody PostCreateRequestDTO postCreateRequestDTO) {
 
         PostCreateResponseDTO response = postService.createPost(postCreateRequestDTO, userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.CREATE_POST_SUCCESS, response);

--- a/src/main/java/com/moongeul/backend/api/post/dto/PostCreateRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/PostCreateRequestDTO.java
@@ -2,11 +2,15 @@ package com.moongeul.backend.api.post.dto;
 
 import com.moongeul.backend.api.book.entity.Book;
 import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.category.entity.Category;
 import com.moongeul.backend.api.post.entity.Post;
+import com.moongeul.backend.api.post.entity.PostVisibility;
 import com.moongeul.backend.api.post.entity.Quote;
 import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -14,9 +18,16 @@ import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PostCreateRequestDTO {
 
     /* 드롭다운 - 필수 입력*/
+    @NotNull(message = "공개여부는 필수입니다")
+    private PostVisibility postVisibility; // 공개 여부
+
+    @NotNull(message = "카테고리는 필수입니다.")
+    private Long categoryId; // 카테고리 번호
 
     /* 필수 입력 */
     @NotBlank(message = "ISBN은 필수입니다")
@@ -45,13 +56,15 @@ public class PostCreateRequestDTO {
         private Integer pageNumber; // 페이지 번호
     }
 
-    public Post toEntity(Member member, Book book) {
+    public Post toEntity(Category category, Member member, Book book) {
         
         // rating과 page가 null로 들어오면 기본값으로 대체
         Double finalRating = (this.rating != null) ? this.rating : 5.0;
         Integer finalPage = (this.page != null) ? this.page : 300;
         
         Post post = Post.builder()
+                .postVisibility(this.postVisibility)
+                .category(category)
                 .readDate(this.readDate)
                 .rating(finalRating)
                 .page(finalPage)

--- a/src/main/java/com/moongeul/backend/api/post/dto/PostCreateResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/PostCreateResponseDTO.java
@@ -1,10 +1,14 @@
 package com.moongeul.backend.api.post.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PostCreateResponseDTO {
 
     private Long postId; // 생성된 Post id

--- a/src/main/java/com/moongeul/backend/api/post/dto/PostResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/PostResponseDTO.java
@@ -1,13 +1,17 @@
 package com.moongeul.backend.api.post.dto;
 
 import com.moongeul.backend.api.book.dto.BookDTO;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PostResponseDTO {
 
     // 필수

--- a/src/main/java/com/moongeul/backend/api/post/entity/Post.java
+++ b/src/main/java/com/moongeul/backend/api/post/entity/Post.java
@@ -1,13 +1,11 @@
 package com.moongeul.backend.api.post.entity;
 
 import com.moongeul.backend.api.book.entity.Book;
+import com.moongeul.backend.api.category.entity.Category;
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -20,7 +18,6 @@ import java.util.List;
 @AllArgsConstructor // 모든 필드를 포함한 생성자
 @Table(name = "POST") // 데이터베이스 테이블 이름 지정
 public class Post extends BaseTimeEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 게시글 id
@@ -30,6 +27,17 @@ public class Post extends BaseTimeEntity {
     private Integer page; // 페이지 수
     private String content; // 감상평
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Quote> quotes = new ArrayList<>(); // 인상깊은구절
+
+    @Enumerated(EnumType.STRING)
+    private PostVisibility postVisibility; // 공개여부
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
@@ -37,14 +45,6 @@ public class Post extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_isbn", nullable = false)
     private Book book;
-
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "category_id", nullable = false)
-//    private Category category;
-
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
-    private List<Quote> quotes = new ArrayList<>(); // 인상깊은구절
 
     public void addQuote(Quote quote) {
         quotes.add(quote);

--- a/src/main/java/com/moongeul/backend/api/post/entity/PostVisibility.java
+++ b/src/main/java/com/moongeul/backend/api/post/entity/PostVisibility.java
@@ -1,0 +1,13 @@
+package com.moongeul.backend.api.post.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostVisibility {
+
+    PUBLIC("ALL"), FOLLOWERS("FOLLOWER_ONLY"), PRIVATE("NONE");
+
+    private final String key;
+}

--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -6,14 +6,18 @@ import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.api.post.dto.PostCreateRequestDTO;
 import com.moongeul.backend.api.post.dto.PostCreateResponseDTO;
+import com.moongeul.backend.api.category.entity.Category;
 import com.moongeul.backend.api.post.entity.Post;
+import com.moongeul.backend.api.category.repository.CategoryRepository;
 import com.moongeul.backend.api.post.repository.PostRepository;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PostService {
@@ -21,6 +25,7 @@ public class PostService {
     private final MemberRepository memberRepository;
     private final BookRepository bookRepository;
     private final PostRepository postRepository;
+    private final CategoryRepository categoryRepository;
 
     /* 글쓰기 */
     @Transactional
@@ -32,7 +37,10 @@ public class PostService {
         Book book = bookRepository.findByIsbn(postCreateRequestDTO.getIsbn())
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.BOOK_NOTFOUND_EXCEPTION.getMessage()));
 
-        Post newPost = postCreateRequestDTO.toEntity(member, book);
+        Category category = categoryRepository.findById(postCreateRequestDTO.getCategoryId())
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage()));
+
+        Post newPost = postCreateRequestDTO.toEntity(category, member, book);
         Post savedPost = postRepository.save(newPost);
 
         return PostCreateResponseDTO.builder()

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -30,7 +30,8 @@ public enum ErrorStatus {
      */
     USER_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND,"해당 사용자를 찾을 수 없습니다."),
     BOOK_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 도서를 찾을 수 없습니다."),
-    
+    CATEGORY_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
+
     /**
      * 400 BAD_REQUEST (추가)
      */

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -13,13 +13,25 @@ public enum SuccessStatus {
 	 * 200
 	 */
 	SEND_HEALTH_CHECK_SUCCESS(HttpStatus.OK,"서버 상태 체크 성공"),
+
+	/* MEMBER */
 	SEND_LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
 	GET_USERINFO_SUCCESS(HttpStatus.OK, "사용자 정보 조회 성공"),
+	REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
+
+	/* BOOK */
 	SEARCH_BOOK_SUCCESS(HttpStatus.OK, "도서 검색 성공"),
+	
+	/* BOOKSHELF */
 	ADD_WISH_READ_BOOK_SUCCESS(HttpStatus.OK, "읽고 싶은 책 등록 성공"),
 	REMOVE_WISH_READ_BOOK_SUCCESS(HttpStatus.OK, "읽고 싶은 책 삭제 성공"),
-	REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
+
+	/* POST */
 	CREATE_POST_SUCCESS(HttpStatus.OK, "글쓰기 성공"),
+
+	/* CATEGORY */
+	CREATE_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 생성 성공"),
+	GET_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 전체 조회 성공"),
 
 	/**
 	 * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #19 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
[ 글쓰기 API ]
- 기록 공개 여부(postVisibility)의 세가지 타입 -> <전체 공개 : PUBLIC, 팔로워 공개 : FOLLOWERS, 나만보기 : PRIVATE>을 enum으로 구현하였습니다.
- 카테고리의 id 값을 받아 Post에 저장하는 코드를 구현하였습니다.

[ 카테고리 API ]
- 카테고리 조회 API: 글쓰기 페이지에서 카테고리 드롭박스의 데이터를 위한 `내 카테고리 전체 조회 API`를 구현하였습니다.
- 카테고리 생성 API: 글쓰기 페이지의 + 컴포넌트를 통해 카테고리를 생성합니다. 생성 즉시 categoryId를 반환하여 `게시` 시, 클라이언트에서 id를 넘겨주고 저장하도록 구현하였습니다.

[ 추가) Authorization Header Value: [null] 삭제 ]
- JwtAuthenticationFilter 클래스 내부에 작성된 디버깅용 로그 때문에 출력되던 로그를 삭제 처리하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="1458" height="707" alt="image" src="https://github.com/user-attachments/assets/163c5efe-3470-452c-9bfb-603cd9f969c3" />
=> postVisibility, categoryId 추가<br/>

<img width="1456" height="454" alt="image" src="https://github.com/user-attachments/assets/9ceb8693-f99d-4357-93be-8f6177e29169" />
=> 카테고리명을 입력하면 저장됩니다.<br/>

<img width="1469" height="755" alt="image" src="https://github.com/user-attachments/assets/a1d70c2b-dbe8-47c0-9f81-c748adf5c3d3" />
=> Id(번호)와 title(카테고리명)을 반환합니다. 카테고리가 여러 개이므로 List로 반환됩니다.<br/>