### PR TITLE
[FEAT] 기록 상세 페이지 API 구현 (조회/수정/삭제)

### DIFF
--- a/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
+++ b/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
@@ -1,7 +1,8 @@
 package com.moongeul.backend.api.post.controller;
 
-import com.moongeul.backend.api.post.dto.PostCreateRequestDTO;
-import com.moongeul.backend.api.post.dto.PostCreateResponseDTO;
+import com.moongeul.backend.api.post.dto.PostRequestDTO;
+import com.moongeul.backend.api.post.dto.PostIdResponseDTO;
+import com.moongeul.backend.api.post.dto.PostResponseDTO;
 import com.moongeul.backend.api.post.service.PostService;
 import com.moongeul.backend.common.response.ApiResponse;
 import com.moongeul.backend.common.response.SuccessStatus;
@@ -36,10 +37,59 @@ public class PostController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 도서를 찾을 수 없습니다.")
     })
     @PostMapping("/create")
-    public ResponseEntity<ApiResponse<PostCreateResponseDTO>> createPost(@AuthenticationPrincipal UserDetails userDetails,
-                                                                         @Valid @RequestBody PostCreateRequestDTO postCreateRequestDTO) {
+    public ResponseEntity<ApiResponse<PostIdResponseDTO>> createPost(@AuthenticationPrincipal UserDetails userDetails,
+                                                                     @Valid @RequestBody PostRequestDTO postRequestDTO) {
 
-        PostCreateResponseDTO response = postService.createPost(postCreateRequestDTO, userDetails.getUsername());
+        PostIdResponseDTO response = postService.createPost(postRequestDTO, userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.CREATE_POST_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "기록(게시글) 상세 조회 API",
+            description = "기록(게시글)의 상세 조회 API 입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "기록(게시글) 상세 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 기록(게시글)을 찾을 수 없습니다.")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<PostResponseDTO>> getPost(@PathVariable Long id) {
+
+        PostResponseDTO response = postService.getPostDetail(id);
+        return ApiResponse.success(SuccessStatus.GET_POST_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "기록(게시글) 수정 API",
+            description = "기록(게시글)을 수정하는 API 입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "기록(게시글) 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "수정하려는 회원의 게시글이 아닙니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 기록(게시글)을 찾을 수 없습니다.")
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<PostIdResponseDTO>> updatePost(@AuthenticationPrincipal UserDetails userDetails,
+                                                                   @PathVariable Long id,
+                                                                   @Valid @RequestBody PostRequestDTO postRequestDTO) {
+
+        PostIdResponseDTO response = postService.updatePost(id, userDetails.getUsername(), postRequestDTO);
+        return ApiResponse.success(SuccessStatus.UPDATE_POST_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "기록(게시글) 삭제 API",
+            description = "기록(게시글)을 삭제하는 API 입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "기록(게시글) 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 기록(게시글)을 찾을 수 없습니다.")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deletePost(@AuthenticationPrincipal UserDetails userDetails,
+                                                                   @PathVariable Long id) {
+
+        postService.deletePost(id, userDetails.getUsername());
+        return ApiResponse.success_only(SuccessStatus.DELETE_POST_SUCCESS);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/post/dto/PostIdResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/PostIdResponseDTO.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PostCreateResponseDTO {
+public class PostIdResponseDTO {
 
     private Long postId; // 생성된 Post id
 }

--- a/src/main/java/com/moongeul/backend/api/post/dto/PostRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/PostRequestDTO.java
@@ -5,7 +5,6 @@ import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.category.entity.Category;
 import com.moongeul.backend.api.post.entity.Post;
 import com.moongeul.backend.api.post.entity.PostVisibility;
-import com.moongeul.backend.api.post.entity.Quote;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,14 +12,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PostCreateRequestDTO {
+public class PostRequestDTO {
 
     /* 드롭다운 - 필수 입력*/
     @NotNull(message = "공개여부는 필수입니다")
@@ -51,8 +49,9 @@ public class PostCreateRequestDTO {
     private List<QuoteRequestDTO> quotes; // 인상깊은구절
 
     @Getter
+    @Builder
     public static class QuoteRequestDTO {
-        private String quote; // 인용문 내용
+        private String quoteContent; // 인용문 내용
         private Integer pageNumber; // 페이지 번호
     }
 
@@ -62,7 +61,7 @@ public class PostCreateRequestDTO {
         Double finalRating = (this.rating != null) ? this.rating : 5.0;
         Integer finalPage = (this.page != null) ? this.page : 300;
         
-        Post post = Post.builder()
+        return Post.builder()
                 .postVisibility(this.postVisibility)
                 .category(category)
                 .readDate(this.readDate)
@@ -72,22 +71,6 @@ public class PostCreateRequestDTO {
                 .member(member)
                 .book(book)
                 .build();
-
-        // Quote 처리
-        if (this.quotes != null && !this.quotes.isEmpty()) {
-            List<Quote> quoteList = new ArrayList<>();
-            for (QuoteRequestDTO quoteDTO : this.quotes) {
-                Quote quote = Quote.builder()
-                        .quoteContent(quoteDTO.getQuote())
-                        .pageNumber(quoteDTO.getPageNumber())
-                        .post(post)
-                        .build();
-                quoteList.add(quote);
-
-                post.addQuotes(quoteList);
-            }
-        }
-        return post;
     }
 
 }

--- a/src/main/java/com/moongeul/backend/api/post/dto/PostResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/PostResponseDTO.java
@@ -1,6 +1,5 @@
 package com.moongeul.backend.api.post.dto;
 
-import com.moongeul.backend.api.book.dto.BookDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,12 +13,27 @@ import java.util.List;
 @AllArgsConstructor
 public class PostResponseDTO {
 
-    // 필수
-    private BookDTO bookDTO; // 필요 - 책 제목/작가/출판사
-    private double rating;
-    
-    // 선택
+    private BookInfo bookInfo; // 책 정보
+    private double rating; // 별점
     private String content; // 감상평
-    private List<String> quotes; // 인상깊은구절 리스트
+    private List<QuoteDTO> quotes; // 인상깊은구절 리스트
+
+    @Getter
+    @Builder
+    public static class BookInfo{
+
+        private String isbn; // ISBN
+        private String bookImage; // 표지 이미지
+        private String title; // 책 제목
+        private String author; // 저자
+        private String publisher; // 출판사
+    }
+
+    @Getter
+    @Builder
+    public static class QuoteDTO {
+        private String quoteContent; // 인용문 내용
+        private Integer pageNumber; // 페이지 번호
+    }
     
 }

--- a/src/main/java/com/moongeul/backend/api/post/entity/Post.java
+++ b/src/main/java/com/moongeul/backend/api/post/entity/Post.java
@@ -8,8 +8,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -27,10 +25,6 @@ public class Post extends BaseTimeEntity {
     private Integer page; // 페이지 수
     private String content; // 감상평
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
-    private List<Quote> quotes = new ArrayList<>(); // 인상깊은구절
-
     @Enumerated(EnumType.STRING)
     private PostVisibility postVisibility; // 공개여부
 
@@ -46,11 +40,20 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "book_isbn", nullable = false)
     private Book book;
 
-    public void addQuote(Quote quote) {
-        quotes.add(quote);
-    }
-
-    public void addQuotes(List<Quote> quoteList) {
-        quoteList.forEach(this::addQuote);
+    // 게시글 수정
+    public void update(LocalDate readDate,
+                       Double rating,
+                       Integer page,
+                       String content,
+                       PostVisibility postVisibility,
+                       Category category,
+                       Book book) {
+        this.readDate = readDate;
+        this.rating = rating;
+        this.page = page;
+        this.content = content;
+        this.postVisibility = postVisibility;
+        this.category = category;
+        this.book = book;
     }
 }

--- a/src/main/java/com/moongeul/backend/api/post/repository/QuoteRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/QuoteRepository.java
@@ -1,0 +1,13 @@
+package com.moongeul.backend.api.post.repository;
+
+import com.moongeul.backend.api.post.entity.Quote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface QuoteRepository extends JpaRepository<Quote, Long> {
+
+    List<Quote> findByPostId(Long postId);
+
+    void deleteAllByPostId(Long postId);
+}

--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -4,18 +4,25 @@ import com.moongeul.backend.api.book.entity.Book;
 import com.moongeul.backend.api.book.repository.BookRepository;
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.repository.MemberRepository;
-import com.moongeul.backend.api.post.dto.PostCreateRequestDTO;
-import com.moongeul.backend.api.post.dto.PostCreateResponseDTO;
+import com.moongeul.backend.api.post.dto.PostRequestDTO;
+import com.moongeul.backend.api.post.dto.PostIdResponseDTO;
 import com.moongeul.backend.api.category.entity.Category;
+import com.moongeul.backend.api.post.dto.PostResponseDTO;
 import com.moongeul.backend.api.post.entity.Post;
 import com.moongeul.backend.api.category.repository.CategoryRepository;
+import com.moongeul.backend.api.post.entity.Quote;
 import com.moongeul.backend.api.post.repository.PostRepository;
+import com.moongeul.backend.api.post.repository.QuoteRepository;
 import com.moongeul.backend.common.exception.NotFoundException;
+import com.moongeul.backend.common.exception.UnauthorizedException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -26,25 +33,168 @@ public class PostService {
     private final BookRepository bookRepository;
     private final PostRepository postRepository;
     private final CategoryRepository categoryRepository;
+    private final QuoteRepository quoteRepository;
 
     /* 글쓰기 */
     @Transactional
-    public PostCreateResponseDTO createPost(PostCreateRequestDTO postCreateRequestDTO, String email){
+    public PostIdResponseDTO createPost(PostRequestDTO postRequestDTO, String email){
 
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
-
-        Book book = bookRepository.findByIsbn(postCreateRequestDTO.getIsbn())
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.BOOK_NOTFOUND_EXCEPTION.getMessage()));
-
-        Category category = categoryRepository.findById(postCreateRequestDTO.getCategoryId())
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage()));
-
-        Post newPost = postCreateRequestDTO.toEntity(category, member, book);
+        Member member = getMemberByEmail(email);
+        Book book = getBook(postRequestDTO.getIsbn());
+        Category category = getCategory(postRequestDTO.getCategoryId());
+        
+        Post newPost = postRequestDTO.toEntity(category, member, book);
         Post savedPost = postRepository.save(newPost);
 
-        return PostCreateResponseDTO.builder()
+        // Quote 저장
+        saveQuotes(postRequestDTO, savedPost);
+
+        return PostIdResponseDTO.builder()
                 .postId(savedPost.getId())
                 .build();
+    }
+
+    /* 기록(게시글) 상세 조회 */
+    @Transactional
+    public PostResponseDTO getPostDetail(Long postId){
+
+        Post post = getPost(postId);
+        Book book = getBook(post.getBook().getIsbn());
+
+        // 책 정보(필요 정보만) DTO
+        PostResponseDTO.BookInfo bookInfo = PostResponseDTO.BookInfo.builder()
+                .isbn(book.getIsbn())
+                .bookImage(book.getBookImage())
+                .title(book.getTitle())
+                .author(book.getAuthor())
+                .publisher(book.getPublisher())
+                .build();
+
+        // 인상깊은구절 조회
+        List<Quote> quotes = quoteRepository.findByPostId(postId); // 리스트 반환이기에 `orElseThrow()` 사용 x
+        List<PostResponseDTO.QuoteDTO> quoteDTOList = new ArrayList<>();
+        for(Quote quote : quotes){
+            PostResponseDTO.QuoteDTO quoteDTO = PostResponseDTO.QuoteDTO.builder()
+                    .quoteContent(quote.getQuoteContent())
+                    .pageNumber(quote.getPageNumber())
+                    .build();
+            quoteDTOList.add(quoteDTO);
+        }
+
+        return PostResponseDTO.builder()
+                .bookInfo(bookInfo)
+                .rating(post.getRating())
+                .content(post.getContent())
+                .quotes(quoteDTOList)
+                .build();
+    }
+
+    /* 기록(게시글) 수정 */
+    @Transactional
+    public PostIdResponseDTO updatePost(Long postId, String email, PostRequestDTO postRequestDTO){
+
+        Post post = getPost(postId);
+        Category category = getCategory(postRequestDTO.getCategoryId());
+        Book book = getBook(post.getBook().getIsbn());
+
+        // 예외처리: 수정하는 사람과 게시글 주인이 같은지 확인 (본인의 게시글인지)
+        if (!post.getMember().getEmail().equals(email)) {
+            throw new UnauthorizedException(ErrorStatus.POST_UNAUTHORIZED.getMessage());
+        }
+
+        // 예외처리: 수정하는 사람과 카테고리 주인이 같은지 확인 (본인의 카테고리인지)
+        if (!category.getMember().getEmail().equals(email)) {
+            throw new UnauthorizedException(ErrorStatus.CATEGORY_UNAUTHORIZED.getMessage());
+        }
+
+        // 예외처리: 수정한 책 정보가 Book 테이블에 저장되어 있지 않은 경우 -> 저장
+        // (책 검색 시 저장되기 때문에 우선 처리x, 대신 책에 대한 NOT_FOUND 에러 throw)
+
+
+        // (1) 기존 인상깊은구절 일괄 삭제 -> 전체 교체 방식 적용
+        // 이유: 데이터가 많지 않으므로(최대 10개) 성능 이슈가 없고, 클라이언트 편의성 높이고 유지보수 간결
+        quoteRepository.deleteAllByPostId(postId);
+
+        // (2) 새로운 인상깊은구절 저장
+        saveQuotes(postRequestDTO, post);
+
+        // rating과 page가 null로 들어오면 기본값으로 대체
+        Double finalRating = (postRequestDTO.getRating() != null) ? postRequestDTO.getRating() : 5.0;
+        Integer finalPage = (postRequestDTO.getPage() != null) ? postRequestDTO.getPage() : 300;
+
+        // 기록(게시글) 내용 갱신
+        post.update(
+                postRequestDTO.getReadDate(),
+                finalRating,
+                finalPage,
+                postRequestDTO.getContent(),
+                postRequestDTO.getPostVisibility(),
+                category,
+                book
+        );
+
+        return PostIdResponseDTO.builder()
+                .postId(post.getId())
+                .build();
+    }
+
+    /* 기록(게시글) 삭제 */
+    @Transactional
+    public void deletePost(Long postId, String email){
+
+        Post post = getPost(postId);
+
+        // 예외처리: 수정하는 사람과 게시글 주인이 같은지 확인 (본인의 게시글인지)
+        if (!post.getMember().getEmail().equals(email)) {
+            throw new UnauthorizedException(ErrorStatus.POST_UNAUTHORIZED.getMessage());
+        }
+
+        // 인상깊은구절 일괄 삭제
+        quoteRepository.deleteAllByPostId(postId);
+
+        // 게시글 삭제
+        postRepository.delete(post);
+    }
+    
+    
+    // 새로운 인상깊은구절 저장
+    private void saveQuotes(PostRequestDTO postRequestDTO, Post post){
+        
+        if (postRequestDTO.getQuotes() != null && !postRequestDTO.getQuotes().isEmpty()){
+            for(PostRequestDTO.QuoteRequestDTO quoteRequestDTO : postRequestDTO.getQuotes()){
+                Quote quote = Quote.builder()
+                        .quoteContent(quoteRequestDTO.getQuoteContent())
+                        .pageNumber(quoteRequestDTO.getPageNumber())
+                        .post(post)
+                        .build();
+
+                quoteRepository.save(quote);
+            }
+        }
+    }
+
+
+    /*
+    * 단순 데이터 불러오기용 코드 메서드 - 코드 깔끔하게 하기용
+    */
+
+    private Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    }
+
+    private Book getBook(String isbn) {
+        return bookRepository.findByIsbn(isbn)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.BOOK_NOTFOUND_EXCEPTION.getMessage()));
+    }
+
+    private Post getPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.POST_NOTFOUND_EXCEPTION.getMessage()));
+    }
+
+    private Category getCategory(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage()));
     }
 }

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -24,12 +24,15 @@ public enum ErrorStatus {
      */
     AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "유효하지 않은 인가코드 입니다."),
     TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었거나 유효하지 않은 토큰입니다."),
+    POST_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "수정하려는 회원의 게시글이 아닙니다."),
+    CATEGORY_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "수정하려는 회원의 카테고리가 아닙니다."),
 
     /**
      * 404 NOT_FOUND
      */
     USER_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND,"해당 사용자를 찾을 수 없습니다."),
     BOOK_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 도서를 찾을 수 없습니다."),
+    POST_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 기록(게시글)을 찾을 수 없습니다."),
     CATEGORY_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
 
     /**

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -28,6 +28,9 @@ public enum SuccessStatus {
 
 	/* POST */
 	CREATE_POST_SUCCESS(HttpStatus.OK, "글쓰기 성공"),
+	GET_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 상세 조회 성공"),
+	UPDATE_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 수정 성공"),
+	DELETE_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 삭제 성공"),
 
 	/* CATEGORY */
 	CREATE_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 생성 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #23 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
기록 상세 페이지 API를 구현하였습니다. (조회/수정/삭제)
- 기록(게시글) 수정 API : 수정 시, 변경되는 **인상깊은구절의 갱신 처리**는 **일괄 삭제 후 재등록(방식1)**으로 구현하였습니다.
  - 방식1. 전체 교체 방식: 수정 요청 시 기존 인용구를 모두 삭제하고 새로 받은 리스트로 교체합니다.
  - 방식2. ID 기반 부분 수정 방식 (Partial Update with ID): 클라이언트가 Quote의 ID를 포함해서 전송하고, ID 유무로 생성/수정/삭제를 판단합니다.
  - **`방식1 선택 이유`** => 처리해야 할 데이터가 많지 않으므로(최대 10개) 성능 이슈가 없고, 방식2에 비해 클라이언트가 ID를 관리해야할 필요가 없어 편의성 높입니다. 또한, 코드가 간결하고 유지보수가 쉽다는 점에 착안하여 채택하였습니다.

(수정 사항)
- Quote 저장 처리를 변경하였습니다.
-> 기존 Post entity 내 필드에서 연동되어 관리하던 Quote를 따로 분리하여 Quote 테이블 자체에서만 저장&수정&삭제 되도록 수정하였습니다.
- DTO의 재사용이 많아 DTO name을 용도에 더 맞게 범용적으로 수정하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="1461" height="320" alt="image" src="https://github.com/user-attachments/assets/c86f29d0-8fc7-419f-9b51-3bb085078928" />
