### PR TITLE
[FIX] 글쓰기 API 필수 요소(공개여부/카테고리) 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
+++ b/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
@@ -27,8 +27,8 @@ public class PostController {
     @Operation(
             summary = "글쓰기 API",
             description = "기록(게시글)을 작성하는 글쓰기 API 입니다." +
-                    "<br>필수: isbn, readDate / 선택: rating(default = 5.0), page(default = 300), content, quotes" +
-                    "<br>선택 요소의 경우 입력되지 않았을 때 'null'로 전달 바랍니다." +
+                    "<br><br>드롭박스 - 선택: postVisibility(default = PUBLIC), categoryId(default = 0(전체보기)) -> 입력되지 않았을 경우, 각각의 기본값(postVisibility: PUBLIC, categoryId: 0)으로 전달 바랍니다." +
+                    "<br>필수: isbn, readDate / 선택: rating(default = 5.0), page(default = 300), content, quotes -> 입력되지 않았을 경우, 'null'로 전달 바랍니다." +
                     "<br><br>[enum] postVisibility -> 전체 공개 : PUBLIC, 팔로워 공개 : FOLLOWERS, 나만보기 : PRIVATE"
     )
     @ApiResponses({

--- a/src/main/java/com/moongeul/backend/api/post/dto/PostRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/PostRequestDTO.java
@@ -20,11 +20,8 @@ import java.util.List;
 @AllArgsConstructor
 public class PostRequestDTO {
 
-    /* 드롭다운 - 필수 입력*/
-    @NotNull(message = "공개여부는 필수입니다")
+    /* 드롭다운 - 선택 입력*/
     private PostVisibility postVisibility; // 공개 여부
-
-    @NotNull(message = "카테고리는 필수입니다.")
     private Long categoryId; // 카테고리 번호
 
     /* 필수 입력 */

--- a/src/main/java/com/moongeul/backend/api/post/entity/Post.java
+++ b/src/main/java/com/moongeul/backend/api/post/entity/Post.java
@@ -29,7 +29,7 @@ public class Post extends BaseTimeEntity {
     private PostVisibility postVisibility; // 공개여부
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id", nullable = false)
+    @JoinColumn(name = "category_id", nullable = true)
     private Category category;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -41,7 +41,11 @@ public class PostService {
 
         Member member = getMemberByEmail(email);
         Book book = getBook(postRequestDTO.getIsbn());
-        Category category = getCategory(postRequestDTO.getCategoryId());
+
+        Category category = null;
+        if(postRequestDTO.getCategoryId() != 0){
+            category = getCategory(postRequestDTO.getCategoryId());
+        }
         
         Post newPost = postRequestDTO.toEntity(category, member, book);
         Post savedPost = postRepository.save(newPost);


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #25 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 글쓰기 API의 공개여부/카테고리 요소를 필수 -> 선택으로 변경하였습니다.
- 공개여부를 선택하지 않을 경우, `PUBLIC` 기본 설정
- 카테고리를 선택하지 않을 경우, null 값이 입력되고, 이는 카테고리의 `전체보기` 탭에 들어가게 됩니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="1048" height="257" alt="image" src="https://github.com/user-attachments/assets/217e6167-d07a-4a3a-ae04-cd0ecdeb52eb" />
