### PR TITLE
[FEAT] 공감 토글 API 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
+++ b/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
@@ -118,4 +118,28 @@ public class PostController {
         postService.deletePost(id, userDetails.getUsername());
         return ApiResponse.success_only(SuccessStatus.DELETE_POST_SUCCESS);
     }
+
+    @Operation(
+            summary = "공감 토글 API",
+            description = "기록(게시글)에 공감 표시 시 사용하는 공감 토글 API 입니다." +
+                    "<br><br>[enum] 기록(게시글) 공감 유형 ->" +
+                    "<br>- RELATABLE: 공감돼요" +
+                    "<br>- SAME_TASTE: 취향이 같아요" +
+                    "<br>- IMPRESSIVE_EXPRESSION: 표현이 인상적이에요" +
+                    "<br>- WANT_TO_READ: 읽고 싶네요" +
+                    "<br>- HELPFUL: 도움이 됐어요"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "기록(게시글) 공감 버튼 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "공감 유형은 필수 입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 기록(게시글)을 찾을 수 없습니다.")
+    })
+    @PostMapping("/like/{id}")
+    public ResponseEntity<ApiResponse<Void>> LikePost(@AuthenticationPrincipal UserDetails userDetails,
+                                                      @PathVariable Long id,
+                                                      @Valid @RequestBody LikeDTO likeDTO) {
+
+        postService.likePost(id, userDetails.getUsername(), likeDTO);
+        return ApiResponse.success_only(SuccessStatus.POST_LIKE_SUCCESS);
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/post/dto/LikeDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/LikeDTO.java
@@ -1,0 +1,29 @@
+package com.moongeul.backend.api.post.dto;
+
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.post.entity.Likes;
+import com.moongeul.backend.api.post.entity.LikeType;
+import com.moongeul.backend.api.post.entity.Post;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LikeDTO {
+
+    @NotNull(message = "공감 유형은 필수 입니다.")
+    private LikeType likeType; // 공감 유형
+
+    public Likes toEntity(Member member, Post post){
+        return Likes.builder()
+                .member(member)
+                .post(post)
+                .likeType(this.likeType)
+                .build();
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/post/dto/PostRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/PostRequestDTO.java
@@ -65,6 +65,11 @@ public class PostRequestDTO {
                 .rating(finalRating)
                 .page(finalPage)
                 .content(this.content)
+                .relatableCount(0)
+                .sameTasteCount(0)
+                .impressiveExpressionCount(0)
+                .wantToReadCount(0)
+                .helpfulCount(0)
                 .member(member)
                 .book(book)
                 .build();

--- a/src/main/java/com/moongeul/backend/api/post/entity/LikeType.java
+++ b/src/main/java/com/moongeul/backend/api/post/entity/LikeType.java
@@ -1,0 +1,17 @@
+package com.moongeul.backend.api.post.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LikeType {
+
+    RELATABLE("공감돼요"),
+    SAME_TASTE("취향이 같아요"),
+    IMPRESSIVE_EXPRESSION("표현이 인상적이에요"),
+    WANT_TO_READ("읽고 싶네요"),
+    HELPFUL("도움이 됐어요");
+
+    private final String key;
+}

--- a/src/main/java/com/moongeul/backend/api/post/entity/Likes.java
+++ b/src/main/java/com/moongeul/backend/api/post/entity/Likes.java
@@ -1,0 +1,39 @@
+package com.moongeul.backend.api.post.entity;
+
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder // 빌더 패턴 사용을 위한 롬복 애너테이션
+@NoArgsConstructor // 기본 생성자
+@AllArgsConstructor // 모든 필드를 포함한 생성자
+@Table(name = "LIKES") // 데이터베이스 테이블 이름 지정
+public class Likes extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post; // 어떤 게시글에 눌렀는지
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member; // 누가 눌렀는지
+
+    @Enumerated(EnumType.STRING)
+    private LikeType likeType; // 공감 유형
+
+    // 공감 타입 변경 메서드
+    public void changeLikeType(LikeType newLikeType) {
+        this.likeType = newLikeType;
+    }
+
+}

--- a/src/main/java/com/moongeul/backend/api/post/entity/Post.java
+++ b/src/main/java/com/moongeul/backend/api/post/entity/Post.java
@@ -28,6 +28,19 @@ public class Post extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private PostVisibility postVisibility; // 공개여부
 
+    // 공감 유형 별 개수 필드들
+    @Column(nullable = false)
+    private Integer relatableCount = 0; // 공감돼요
+    @Column(nullable = false)
+    private Integer sameTasteCount = 0; // 취향이 같아요
+    @Column(nullable = false)
+    private Integer impressiveExpressionCount = 0; // 표현이 인상적이에요
+    @Column(nullable = false)
+    private Integer wantToReadCount = 0; // 읽고싶네요
+    @Column(nullable = false)
+    private Integer helpfulCount = 0; // 도움이 됐어요
+
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = true)
     private Category category;
@@ -55,5 +68,29 @@ public class Post extends BaseTimeEntity {
         this.postVisibility = postVisibility;
         this.category = category;
         this.book = book;
+    }
+
+    // 공감 개수 증가 메서드들
+    public void incrementRelatableCount() { this.relatableCount++; }
+    public void incrementSameTasteCount() { this.sameTasteCount++; }
+    public void incrementImpressiveExpressionCount() { this.impressiveExpressionCount++; }
+    public void incrementWantToReadCount() { this.wantToReadCount++; }
+    public void incrementHelpfulCount() { this.helpfulCount++; }
+
+    // 공감 개수 감소 메서드들
+    public void decrementRelatableCount() {
+        if (this.relatableCount > 0) this.relatableCount--;
+    }
+    public void decrementSameTasteCount() {
+        if (this.sameTasteCount > 0) this.sameTasteCount--;
+    }
+    public void decrementImpressiveExpressionCount() {
+        if (this.impressiveExpressionCount > 0) this.impressiveExpressionCount--;
+    }
+    public void decrementWantToReadCount() {
+        if (this.wantToReadCount > 0) this.wantToReadCount--;
+    }
+    public void decrementHelpfulCount() {
+        if (this.helpfulCount > 0) this.helpfulCount--;
     }
 }

--- a/src/main/java/com/moongeul/backend/api/post/repository/LikeRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/LikeRepository.java
@@ -1,0 +1,11 @@
+package com.moongeul.backend.api.post.repository;
+
+import com.moongeul.backend.api.post.entity.Likes;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LikeRepository extends JpaRepository<Likes, Long> {
+
+    Optional<Likes> findByPostIdAndMemberId(Long postId, Long memberId);
+}

--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -9,10 +9,9 @@ import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.api.post.dto.*;
 import com.moongeul.backend.api.category.entity.Category;
-import com.moongeul.backend.api.post.entity.Post;
+import com.moongeul.backend.api.post.entity.*;
 import com.moongeul.backend.api.category.repository.CategoryRepository;
-import com.moongeul.backend.api.post.entity.PostVisibility;
-import com.moongeul.backend.api.post.entity.Quote;
+import com.moongeul.backend.api.post.repository.LikeRepository;
 import com.moongeul.backend.api.post.repository.PostRepository;
 import com.moongeul.backend.api.post.repository.QuoteRepository;
 import com.moongeul.backend.common.exception.NotFoundException;
@@ -28,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -37,6 +37,7 @@ public class PostService {
     private final MemberRepository memberRepository;
     private final BookRepository bookRepository;
     private final PostRepository postRepository;
+    private final LikeRepository likeRepository;
     private final CategoryRepository categoryRepository;
     private final QuoteRepository quoteRepository;
     private final DoneReadBookshelfRepository doneReadBookshelfRepository;
@@ -238,6 +239,60 @@ public class PostService {
 
                 quoteRepository.save(quote);
             }
+        }
+    }
+
+    /* 공감 토글 */
+    @Transactional
+    public void likePost(Long postId, String email, LikeDTO likeDTO){
+
+        Member member = getMemberByEmail(email);
+        Post post = getPost(postId);
+
+        // 사용자가 해당 게시글에 누른 공감 유형이 있다면
+        Optional<Likes> existingLike = likeRepository.findByPostIdAndMemberId(postId, member.getId());
+
+        if(existingLike.isPresent()){
+            Likes currentLikes = existingLike.get();
+
+            // 사용자가 해당 게시글에 누른 "같은 공감 유형"이 있다면(또 누른 경우) -> 공감 삭제
+            if (currentLikes.getLikeType().equals(likeDTO.getLikeType())) {
+                decrementLikeCount(post, currentLikes.getLikeType());
+                likeRepository.delete(currentLikes);
+                return;
+            }
+
+            // 사용자가 해당 게시글에 누른 "다른 공감 유형"이 있다면 -> 공감 유형 수정
+            decrementLikeCount(post, currentLikes.getLikeType());
+            currentLikes.changeLikeType(likeDTO.getLikeType());
+            incrementLikeCount(post, likeDTO.getLikeType());
+            return;
+        }
+        
+        // 처음 공감을 누르는 경우 -> 새로 저장
+        likeRepository.save(likeDTO.toEntity(member, post));
+        incrementLikeCount(post, likeDTO.getLikeType());
+    }
+
+    // 공감 카운트 증가 메서드
+    private void incrementLikeCount(Post post, LikeType likeType) {
+        switch (likeType) {
+            case RELATABLE: post.incrementRelatableCount(); break;
+            case SAME_TASTE: post.incrementSameTasteCount(); break;
+            case IMPRESSIVE_EXPRESSION: post.incrementImpressiveExpressionCount(); break;
+            case WANT_TO_READ: post.incrementWantToReadCount(); break;
+            case HELPFUL: post.incrementHelpfulCount(); break;
+        }
+    }
+
+    // 공감 카운트 감소 메서드
+    private void decrementLikeCount(Post post, LikeType likeType) {
+        switch (likeType) {
+            case RELATABLE: post.decrementRelatableCount(); break;
+            case SAME_TASTE: post.decrementSameTasteCount(); break;
+            case IMPRESSIVE_EXPRESSION: post.decrementImpressiveExpressionCount(); break;
+            case WANT_TO_READ: post.decrementWantToReadCount(); break;
+            case HELPFUL: post.decrementHelpfulCount(); break;
         }
     }
 

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -39,6 +39,7 @@ public enum SuccessStatus {
 	GET_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 상세 조회 성공"),
 	UPDATE_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 수정 성공"),
 	DELETE_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 삭제 성공"),
+	POST_LIKE_SUCCESS(HttpStatus.OK, "기록(게시글) 공감 버튼 등록 성공"),
 
 	/* CATEGORY */
 	GET_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 전체 조회 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #35 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
기록(게시글)에 대한 공감 토글 API를 구현하였습니다.
- 해당 API 하나로 공감 수정/삭제가 가능합니다.
  - 한 사용자가 같은 게시글에 하나의 공감만 등록할 수 있음
  - 사용자가 해당 게시글에 누른 "같은 공감 유형"이 있다면(또 누른 경우) -> 공감 삭제
  - 사용자가 해당 게시글에 누른 "다른 공감 유형"이 있다면 -> 공감 유형 수정
- 성능 최적화를 위해 Post 테이블에 각 공감 유형의 개수를 카운트하여 미리 저장해두었습니다. (매번 계산하지 않아도 됨)

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
Likes 테이블 데이터 저장 시
<img width="1239" height="182" alt="image" src="https://github.com/user-attachments/assets/74a5fe0d-3b9d-42f5-97f0-3ca88475f70f" />
<br>
Post 테이블 구조
<img width="651" height="509" alt="image" src="https://github.com/user-attachments/assets/306b0da2-13ca-4f30-9fd9-48f948c243f9" />