### PR TITLE
[FEAT] 팔로우/언팔로우 API 구현 (+조회 API)

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -140,7 +140,7 @@ public class MemberController {
     @GetMapping("/following")
     public ResponseEntity<ApiResponse<List<UserInfoDTO>>> getFollowings(@AuthenticationPrincipal UserDetails userDetails){
         List<UserInfoDTO> response = followService.getfollowing(userDetails.getUsername());
-        return ApiResponse.success(SuccessStatus.FOLLOW_SUCCESS, response);
+        return ApiResponse.success(SuccessStatus.GET_FOLLOWING_SUCCESS, response);
     }
 
     @Operation(
@@ -154,7 +154,7 @@ public class MemberController {
     @GetMapping("/follower")
     public ResponseEntity<ApiResponse<List<UserInfoDTO>>> getFollowers(@AuthenticationPrincipal UserDetails userDetails){
         List<UserInfoDTO> response = followService.getfollower(userDetails.getUsername());
-        return ApiResponse.success(SuccessStatus.FOLLOW_SUCCESS, response);
+        return ApiResponse.success(SuccessStatus.GET_FOLLOWER_SUCCESS, response);
     }
     
 }

--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -139,7 +139,7 @@ public class MemberController {
     })
     @GetMapping("/following")
     public ResponseEntity<ApiResponse<List<UserInfoDTO>>> getFollowings(@AuthenticationPrincipal UserDetails userDetails){
-        List<UserInfoDTO> response = followService.getfollowing(userDetails.getUsername());
+        List<UserInfoDTO> response = followService.getFollowing(userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.GET_FOLLOWING_SUCCESS, response);
     }
 
@@ -153,7 +153,7 @@ public class MemberController {
     })
     @GetMapping("/follower")
     public ResponseEntity<ApiResponse<List<UserInfoDTO>>> getFollowers(@AuthenticationPrincipal UserDetails userDetails){
-        List<UserInfoDTO> response = followService.getfollower(userDetails.getUsername());
+        List<UserInfoDTO> response = followService.getFollower(userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.GET_FOLLOWER_SUCCESS, response);
     }
     

--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.moongeul.backend.api.member.dto.LoginResponseDTO;
 import com.moongeul.backend.api.member.dto.LoginRequestDTO;
 import com.moongeul.backend.api.member.dto.UserInfoDTO;
 import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
+import com.moongeul.backend.api.member.service.FollowService;
 import com.moongeul.backend.api.member.service.MemberService;
 import com.moongeul.backend.common.response.ApiResponse;
 import com.moongeul.backend.common.response.SuccessStatus;
@@ -17,6 +18,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "Member", description = "Member(회원) 관련 API 입니다.")
 @RestController
 @RequiredArgsConstructor
@@ -24,7 +27,13 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final FollowService followService;
 
+    /*
+     *
+     * 로그인 API
+     *
+     * */
     @Operation(
             summary = "구글 로그인 API",
             description = "구글 인가코드을 통해 사용자의 정보를 등록 및 토큰 + 역할을 발급합니다. " +
@@ -96,6 +105,56 @@ public class MemberController {
     public ResponseEntity<ApiResponse<JwtTokenDTO>> reissueAccessToken(@RequestHeader(value = "Authorization-Refresh") String refreshToken){
         JwtTokenDTO response = memberService.reissueToken(refreshToken);
         return ApiResponse.success(SuccessStatus.REISSUE_TOKEN_SUCCESS, response);
+    }
+
+    /*
+    *
+    * 팔로잉/팔로우 API
+    *
+    * */
+    @Operation(
+            summary = "팔로우/언팔로우 API",
+            description = "사용자를 팔로우 또는 언팔로우 합니다." +
+                    "<br>- 팔로우하고 있는 사용자에게 해당 API를 한 번 더 사용 시, 팔로우가 취소됩니다." +
+                    "<br>- 즉, 팔로우/언팔로우 두 버튼에 모두 해당 API를 사용하시면 됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "팔로우 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
+    })
+    @PostMapping("/follow/{id}")
+    public ResponseEntity<ApiResponse<Void>> follow(@AuthenticationPrincipal UserDetails userDetails,
+                                                           @PathVariable Long id){
+        followService.follow(id, userDetails.getUsername());
+        return ApiResponse.success_only(SuccessStatus.FOLLOW_SUCCESS);
+    }
+
+    @Operation(
+            summary = "팔로잉 사용자 목록 조회 API",
+            description = "내가 팔로우한 사용자(팔로잉)의 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "팔로잉 목록 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
+    })
+    @GetMapping("/following")
+    public ResponseEntity<ApiResponse<List<UserInfoDTO>>> getFollowings(@AuthenticationPrincipal UserDetails userDetails){
+        List<UserInfoDTO> response = followService.getfollowing(userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.FOLLOW_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "팔로워 사용자 목록 조회 API",
+            description = "나를 팔로잉한 사용자(팔로워)의 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "팔로워 목록 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
+    })
+    @GetMapping("/follower")
+    public ResponseEntity<ApiResponse<List<UserInfoDTO>>> getFollowers(@AuthenticationPrincipal UserDetails userDetails){
+        List<UserInfoDTO> response = followService.getfollower(userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.FOLLOW_SUCCESS, response);
     }
     
 }

--- a/src/main/java/com/moongeul/backend/api/member/dto/GoogleInfoResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/GoogleInfoResponseDTO.java
@@ -1,12 +1,18 @@
 package com.moongeul.backend.api.member.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class GoogleInfoResponseDTO {
 
+    @JsonProperty("sub")
     private String id;
     private String email;
     private String name;

--- a/src/main/java/com/moongeul/backend/api/member/entity/Follow.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/Follow.java
@@ -1,0 +1,30 @@
+package com.moongeul.backend.api.member.entity;
+
+import com.moongeul.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder // 빌더 패턴 사용을 위한 롬복 애너테이션
+@NoArgsConstructor // 기본 생성자
+@AllArgsConstructor // 모든 필드를 포함한 생성자
+@Table(name = "FOLLOW") // 데이터베이스 테이블 이름 지정
+public class Follow extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id", nullable = false)
+    private Member following;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id", nullable = false)
+    private Member follower;
+
+}

--- a/src/main/java/com/moongeul/backend/api/member/repository/FollowRepository.java
+++ b/src/main/java/com/moongeul/backend/api/member/repository/FollowRepository.java
@@ -1,0 +1,20 @@
+package com.moongeul.backend.api.member.repository;
+
+import com.moongeul.backend.api.member.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    Optional<Follow> findByFollowingIdAndFollowerId(Long followingId, Long followerId);
+
+    @Query("select f from Follow f join fetch f.following where f.follower.id = :followerId")
+    List<Follow> findByFollowings(@Param("followerId") Long followerId);
+
+    @Query("select f from Follow f join fetch f.follower where f.following.id = :followingId")
+    List<Follow> findByFollowers(@Param("followingId") Long followingId);
+}

--- a/src/main/java/com/moongeul/backend/api/member/service/FollowService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/FollowService.java
@@ -52,8 +52,8 @@ public class FollowService {
         }
     }
 
-    // 팔로잉 사용자 목록 조회
-    @Transactional
+    // 팔로잉 사용자 목록 조회 // 생성, 수정, 삭제가 없는 메서드
+    @Transactional(readOnly = true)
     public List<UserInfoDTO> getFollowing(String email){
         Member follower_member = getMemberByEmail(email);
 

--- a/src/main/java/com/moongeul/backend/api/member/service/FollowService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/FollowService.java
@@ -6,6 +6,7 @@ import com.moongeul.backend.api.member.entity.Follow;
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.repository.FollowRepository;
 import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.common.exception.BadRequestException;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -30,11 +31,16 @@ public class FollowService {
         Member following_member = getById(following_id);
         Member follower_member = getMemberByEmail(email);
 
-        Optional<Follow> existingfollow = followRepository.findByFollowingIdAndFollowerId(following_member.getId(), follower_member.getId());
+        // 에러처리: 자기자신을 팔로우하는 경우 (불가)
+        if(following_member.equals(follower_member)){
+            throw new BadRequestException(ErrorStatus.SELF_FOLLOW_NOT_ALLOWED.getMessage());
+        }
+
+        Optional<Follow> existingFollow = followRepository.findByFollowingIdAndFollowerId(following_member.getId(), follower_member.getId());
 
         // 이미 팔로우하고 있는 사용자라면 -> 팔로우 취소
-        if(existingfollow.isPresent()){
-            Follow currentFollow = existingfollow.get();
+        if(existingFollow.isPresent()){
+            Follow currentFollow = existingFollow.get();
             followRepository.delete(currentFollow);
         } else{ // 처음 팔로우 -> 팔로우 성공
             Follow new_follow = Follow.builder()
@@ -48,7 +54,7 @@ public class FollowService {
 
     // 팔로잉 사용자 목록 조회
     @Transactional
-    public List<UserInfoDTO> getfollowing(String email){
+    public List<UserInfoDTO> getFollowing(String email){
         Member follower_member = getMemberByEmail(email);
 
         return followRepository.findByFollowings(follower_member.getId())
@@ -68,7 +74,7 @@ public class FollowService {
 
     // 팔로워 사용자 목록 조회
     @Transactional(readOnly = true) // 생성, 수정, 삭제가 없는 메서드
-    public List<UserInfoDTO> getfollower(String email){
+    public List<UserInfoDTO> getFollower(String email){
         Member following_member = getMemberByEmail(email);
 
         return followRepository.findByFollowers(following_member.getId())

--- a/src/main/java/com/moongeul/backend/api/member/service/FollowService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/FollowService.java
@@ -1,0 +1,98 @@
+package com.moongeul.backend.api.member.service;
+
+
+import com.moongeul.backend.api.member.dto.UserInfoDTO;
+import com.moongeul.backend.api.member.entity.Follow;
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.repository.FollowRepository;
+import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.common.exception.NotFoundException;
+import com.moongeul.backend.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
+
+    // 팔로우/언팔로우
+    @Transactional
+    public void follow(Long following_id, String email){
+        Member following_member = getById(following_id);
+        Member follower_member = getMemberByEmail(email);
+
+        Optional<Follow> existingfollow = followRepository.findByFollowingIdAndFollowerId(following_member.getId(), follower_member.getId());
+
+        // 이미 팔로우하고 있는 사용자라면 -> 팔로우 취소
+        if(existingfollow.isPresent()){
+            Follow currentFollow = existingfollow.get();
+            followRepository.delete(currentFollow);
+        } else{ // 처음 팔로우 -> 팔로우 성공
+            Follow new_follow = Follow.builder()
+                    .following(following_member)
+                    .follower(follower_member)
+                    .build();
+
+            followRepository.save(new_follow);
+        }
+    }
+
+    // 팔로잉 사용자 목록 조회
+    @Transactional
+    public List<UserInfoDTO> getfollowing(String email){
+        Member follower_member = getMemberByEmail(email);
+
+        return followRepository.findByFollowings(follower_member.getId())
+                .stream()
+                .map(follow -> {
+                    Member following = follow.getFollowing();
+                    return UserInfoDTO.builder()
+                            .id(following.getId())
+                            .name(following.getName())
+                            .profileImage(following.getProfileImage())
+                            .nickname(following.getNickname())
+                            .readingTasteType(following.getReadingTasteType())
+                            .build();
+                })
+                .toList();
+    }
+
+    // 팔로워 사용자 목록 조회
+    @Transactional(readOnly = true) // 생성, 수정, 삭제가 없는 메서드
+    public List<UserInfoDTO> getfollower(String email){
+        Member following_member = getMemberByEmail(email);
+
+        return followRepository.findByFollowers(following_member.getId())
+                .stream()
+                .map(follow -> {
+                    Member follower = follow.getFollower();
+                    return UserInfoDTO.builder()
+                            .id(follower.getId())
+                            .name(follower.getName())
+                            .profileImage(follower.getProfileImage())
+                            .nickname(follower.getNickname())
+                            .readingTasteType(follower.getReadingTasteType())
+                            .build();
+                })
+                .toList();
+    }
+
+    private Member getById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    }
+
+    private Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    }
+}

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -48,6 +48,7 @@ public enum ErrorStatus {
      */
     BOOK_ALREADY_ADDED_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 읽고 싶은 책으로 등록된 도서입니다."),
     REVIEW_ALREADY_EXISTS_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 리뷰를 작성한 도서입니다."),
+    SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자기 자신은 팔로우할 수 없습니다."),
 
     /**
      * 500 SERVER_ERROR

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -19,6 +19,7 @@ public enum SuccessStatus {
 	GET_USERINFO_SUCCESS(HttpStatus.OK, "사용자 정보 조회 성공"),
 	REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
 	CALCULATE_READING_TASTE_SUCCESS(HttpStatus.OK, "독서 취향 테스트 결과 계산 성공"),
+	FOLLOW_SUCCESS(HttpStatus.OK, "팔로우 성공"),
 
 	/* BOOK */
 	SEARCH_BOOK_SUCCESS(HttpStatus.OK, "도서 검색 성공"),

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -20,6 +20,8 @@ public enum SuccessStatus {
 	REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
 	CALCULATE_READING_TASTE_SUCCESS(HttpStatus.OK, "독서 취향 테스트 결과 계산 성공"),
 	FOLLOW_SUCCESS(HttpStatus.OK, "팔로우 성공"),
+	GET_FOLLOWING_SUCCESS(HttpStatus.OK, "팔로잉 목록 조회 성공"),
+	GET_FOLLOWER_SUCCESS(HttpStatus.OK, "팔로워 목록 조회 성공"),
 
 	/* BOOK */
 	SEARCH_BOOK_SUCCESS(HttpStatus.OK, "도서 검색 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #37 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
팔로우/언팔로우 API 구현 (+조회 API) API와 팔로워/팔로잉 조회 API를 구현하였습니다.
- 팔로우/언팔로우 API - API 하나로 팔로우와 언팔로우를 구동합니다. 
  (팔로우되어 있을 경우 -> 언팔로우 / 팔로우되어 있지 않을 경우 -> 팔로우)
- 팔로워/팔로잉 상세 조회 API만 구현했습니다. 마이페이지의 팔로워/팔로잉 개수는 따로 구현하여야 합니다.

❗오류 수정
- 구글 로그인 API에서 socialId가 null로 불러와지는 오류가 있었습니다.
- 이에따라 구글 로그인 시, 한 사람의 계정에서 계속 계정 정보만 수정되고(덮어쓰기) 계정 추가가 되지 않는 오류가 발생하던 것을 수정하였습니다.
  - 오류 이유: socialId 값으로 이미 있는 아이디인지 처리를 하여, 모든 로그인이 null로 가져와져 로그인 정보가 덮어씌워지기 되었음

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->

<img width="1461" height="310" alt="image" src="https://github.com/user-attachments/assets/3bb93e9e-20e6-457e-a7d0-64e35e140a79" />

<img width="989" height="428" alt="image" src="https://github.com/user-attachments/assets/3eca88f0-b6a1-4065-bc82-6769860c1a11" />
