### PR TITLE
[FIX] 기록 전체조회/상세조회 API 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
+++ b/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
@@ -47,7 +47,14 @@ public class PostController {
     @Operation(
             summary = "기록(게시글) 전체 조회 API",
             description = "메인페이지(홈화면)에서 사용되는 기록(게시글)의 전체 조회 API 입니다." +
-                    "<br><br>[enum] postVisibility -> 전체 공개 : PUBLIC, 팔로워 공개 : FOLLOWERS, 나만보기 : PRIVATE"
+                    "<br><br>[enum] postVisibility -> 전체 공개 : PUBLIC, 팔로워 공개 : FOLLOWERS, 나만보기 : PRIVATE" +
+                    "<br><br>[필드 설명]" +
+                    "<br>likesInfo: 공감 버튼 개수 정보" +
+                    "<br>- relatableCount: '공감돼요' 개수" +
+                    "<br>- sameTasteCount: '취향이 같아요' 개수" +
+                    "<br>- impressiveExpressionCount: '표현이 인상적이에요' 개수" +
+                    "<br>- wantToReadCount: '읽고싶네요' 개수" +
+                    "<br>- helpfulCount: '도움이 됐어요' 개수"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "기록(게시글) 전체 조회 성공"),
@@ -72,7 +79,14 @@ public class PostController {
 
     @Operation(
             summary = "기록(게시글) 상세 조회 API",
-            description = "기록(게시글)의 상세 조회 API 입니다."
+            description = "기록(게시글)의 상세 조회 API 입니다." +
+                    "<br><br>[필드 설명]" +
+                    "<br>likesInfo: 공감 버튼 개수 정보" +
+                    "<br>- relatableCount: '공감돼요' 개수" +
+                    "<br>- sameTasteCount: '취향이 같아요' 개수" +
+                    "<br>- impressiveExpressionCount: '표현이 인상적이에요' 개수" +
+                    "<br>- wantToReadCount: '읽고싶네요' 개수" +
+                    "<br>- helpfulCount: '도움이 됐어요' 개수"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "기록(게시글) 상세 조회 성공"),

--- a/src/main/java/com/moongeul/backend/api/post/dto/PostDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/PostDTO.java
@@ -1,10 +1,13 @@
 package com.moongeul.backend.api.post.dto;
 
+import com.moongeul.backend.api.member.entity.ReadingTasteType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -13,10 +16,28 @@ import java.util.List;
 @AllArgsConstructor
 public class PostDTO {
 
+    private MemberInfo memberInfo; // 사용자 정보
+    private LocalDateTime created; // 작성 시간
+
     private BookInfo bookInfo; // 책 정보
-    private double rating; // 별점
+
+    private Double rating; // 별점
     private String content; // 감상평
+    private LocalDate readDate; // 읽은날짜
+
+    private Integer quotesCnt; // 인용 총 개수
     private List<QuoteDTO> quotes; // 인상깊은구절 리스트
+
+    private LikesInfo likesInfo; // 공감 개수 정보
+
+    @Getter
+    @Builder
+    public static class MemberInfo {
+        private Long id;
+        private String nickname; // 닉네임
+        private String profileImage; // 회원 이미지
+        private ReadingTasteType readingTasteType; // 독서 취향 유형
+    }
 
     @Getter
     @Builder
@@ -27,6 +48,7 @@ public class PostDTO {
         private String title; // 책 제목
         private String author; // 저자
         private String publisher; // 출판사
+        private String pubdate; // 출판연도
         private Double ratingAverage; // 별점 평균
     }
 
@@ -35,6 +57,16 @@ public class PostDTO {
     public static class QuoteDTO {
         private String quoteContent; // 인용문 내용
         private Integer pageNumber; // 페이지 번호
+    }
+
+    @Getter
+    @Builder
+    public static class LikesInfo{
+        private Integer relatableCount; // 공감돼요
+        private Integer sameTasteCount; // 취향이 같아요
+        private Integer impressiveExpressionCount; // 표현이 인상적이에요
+        private Integer wantToReadCount; // 읽고싶네요
+        private Integer helpfulCount; // 도움이 됐어요
     }
     
 }

--- a/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package com.moongeul.backend.api.post.repository;
 
 import com.moongeul.backend.api.book.entity.Book;
+import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,4 +14,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // 책의 게시글을 최신순으로 조회
     @Query("SELECT p FROM Post p WHERE p.book = :book ORDER BY p.createdAt DESC")
     Page<Post> findByBookOrderByCreatedAtDesc(@Param("book") Book book, Pageable pageable);
+
+    // 내가 팔로우하는 사람들의 게시물 + 내 게시물 함께 조회 (서브쿼리 활용)
+    @Query("SELECT p FROM Post p " +
+            "WHERE p.member IN (SELECT f.following FROM Follow f WHERE f.follower = :member) " +
+            "OR p.member = :member")
+    Page<Post> findAllByFollower(@Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -53,6 +53,11 @@ public class PostService {
         Category category = null;
         if(postRequestDTO.getCategoryId() != 0){
             category = getCategory(postRequestDTO.getCategoryId());
+
+            // 예외처리: 작성하는 사람과 카테고리 주인이 같은지 확인 (본인의 카테고리인지)
+            if(!category.getMember().getId().equals(member.getId())){
+                throw new UnauthorizedException(ErrorStatus.CATEGORY_UNAUTHORIZED.getMessage());
+            }
         }
         
         Post newPost = postRequestDTO.toEntity(category, member, book);
@@ -93,6 +98,7 @@ public class PostService {
     @Transactional
     public PostAllResponseDTO getPostAll(PostAllRequestDTO postAllRequestDTO, String email){
 
+        Member member = getMemberByEmail(email);
         Pageable pageable = PageRequest.of(postAllRequestDTO.getPage() - 1, postAllRequestDTO.getSize());
 
         // 빈 페이지 객체로 초기화 (null 방지)
@@ -101,8 +107,7 @@ public class PostService {
         if(postAllRequestDTO.getPostVisibility().equals(PostVisibility.PUBLIC)){
             postPage = postRepository.findAll(pageable);
         } else if(postAllRequestDTO.getPostVisibility().equals(PostVisibility.FOLLOWERS)){
-            // TODO: 팔로워 게시물 조회 로직 (예: postRepository.findAllByFollowers(email, pageable))
-            postPage = postRepository.findAll(pageable); // 임시
+            postPage = postRepository.findAllByFollower(member, pageable);
         }
 
         List<PostDTO> postDTOList = new ArrayList<>();
@@ -129,6 +134,14 @@ public class PostService {
         Post post = getPost(postId);
         Book book = getBook(post.getBook().getIsbn());
 
+        // 멤버 정보(필요 정보만) DTO
+        PostDTO.MemberInfo memberInfo = PostDTO.MemberInfo.builder()
+                .id(post.getMember().getId())
+                .nickname(post.getMember().getNickname())
+                .profileImage(post.getMember().getProfileImage())
+                .readingTasteType(post.getMember().getReadingTasteType())
+                .build();
+
         // 책 정보(필요 정보만) DTO
         PostDTO.BookInfo bookInfo = PostDTO.BookInfo.builder()
                 .isbn(book.getIsbn())
@@ -136,6 +149,7 @@ public class PostService {
                 .title(book.getTitle())
                 .author(book.getAuthor())
                 .publisher(book.getPublisher())
+                .pubdate(book.getPubdate())
                 .ratingAverage(book.getRatingAverage())
                 .build();
 
@@ -150,11 +164,25 @@ public class PostService {
             quoteDTOList.add(quoteDTO);
         }
 
+        // 공감 개수 DTO
+        PostDTO.LikesInfo likesInfo = PostDTO.LikesInfo.builder()
+                .relatableCount(post.getRelatableCount())
+                .sameTasteCount(post.getSameTasteCount())
+                .impressiveExpressionCount(post.getImpressiveExpressionCount())
+                .wantToReadCount(post.getWantToReadCount())
+                .helpfulCount(post.getHelpfulCount())
+                .build();
+
         return PostDTO.builder()
+                .memberInfo(memberInfo)
+                .created(post.getCreatedAt())
                 .bookInfo(bookInfo)
                 .rating(post.getRating())
                 .content(post.getContent())
+                .readDate(post.getReadDate())
+                .quotesCnt(quoteDTOList.size())
                 .quotes(quoteDTOList)
+                .likesInfo(likesInfo)
                 .build();
     }
 

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -31,8 +31,8 @@ public enum ErrorStatus {
      */
     AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "유효하지 않은 인가코드 입니다."),
     TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었거나 유효하지 않은 토큰입니다."),
-    POST_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "수정하려는 회원의 게시글이 아닙니다."),
-    CATEGORY_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "수정하려는 회원의 카테고리가 아닙니다."),
+    POST_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "회원의 게시글이 아닙니다."),
+    CATEGORY_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "회원의 카테고리가 아닙니다."),
 
     /**
      * 404 NOT_FOUND


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #39 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기록 전체조회/상세조회 ResponseDTO에 필요한 데이터를 추가/수정하였습니다.
- 기록 전체조회 필터 = 팔로워보기 기능을 추가하였습니다.
- 오류 수정: '글쓰기'에서 타인의 카테고리로 글쓰기를 작성하는 오류를 수정하였습니다. 

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="1004" height="489" alt="image" src="https://github.com/user-attachments/assets/3981155d-a8f0-487c-b6f4-5e5121774f32" />
