### PR TITLE
[FEAT] 랜덤 닉네임 재생성 및 수동 닉네임 등록 기능 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -2,6 +2,8 @@ package com.moongeul.backend.api.member.controller;
 
 import com.moongeul.backend.api.member.dto.LoginResponseDTO;
 import com.moongeul.backend.api.member.dto.LoginRequestDTO;
+import com.moongeul.backend.api.member.dto.NicknameCheckResponseDTO;
+import com.moongeul.backend.api.member.dto.NicknameRequestDTO;
 import com.moongeul.backend.api.member.dto.NicknameResponseDTO;
 import com.moongeul.backend.api.member.dto.UserInfoDTO;
 import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
@@ -159,7 +161,7 @@ public class MemberController {
     }
 
     @Operation(
-            summary = "닉네임 재생성 API",
+            summary = "랜덤 닉네임 재생성 API",
             description = "랜덤 닉네임을 다시 생성하여 등록하고 바뀐 닉네임을 반환합니다."
     )
     @ApiResponses({
@@ -171,6 +173,39 @@ public class MemberController {
 
         NicknameResponseDTO nicknameResponseDTO = memberService.regenerateNickname(userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.REGENERATE_NICKNAME_SUCCESS, nicknameResponseDTO);
+    }
+
+    @Operation(
+            summary = "닉네임 등록 API",
+            description = "사용자가 직접 입력한 닉네임을 등록합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 사용 중인 닉네임입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
+    })
+    @PatchMapping("/nickname")
+    public ResponseEntity<ApiResponse<NicknameResponseDTO>> updateNickname(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody NicknameRequestDTO nicknameRequestDTO) {
+        
+        NicknameResponseDTO nicknameResponseDTO = memberService.updateNickname(userDetails.getUsername(), nicknameRequestDTO);
+        return ApiResponse.success(SuccessStatus.UPDATE_NICKNAME_SUCCESS, nicknameResponseDTO);
+    }
+
+    @Operation(
+            summary = "닉네임 중복 체크 API",
+            description = "전달받은 닉네임이 중복인지 체크합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 중복 체크 성공")
+    })
+    @GetMapping("/nickname/check")
+    public ResponseEntity<ApiResponse<NicknameCheckResponseDTO>> checkNicknameDuplicate(
+            @RequestParam String nickname) {
+        
+        NicknameCheckResponseDTO nicknameCheckResponseDTO = memberService.checkNicknameDuplicate(nickname);
+        return ApiResponse.success(SuccessStatus.CHECK_NICKNAME_DUPLICATE_SUCCESS, nicknameCheckResponseDTO);
     }
     
 }

--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.moongeul.backend.api.member.controller;
 
 import com.moongeul.backend.api.member.dto.LoginResponseDTO;
 import com.moongeul.backend.api.member.dto.LoginRequestDTO;
+import com.moongeul.backend.api.member.dto.NicknameResponseDTO;
 import com.moongeul.backend.api.member.dto.UserInfoDTO;
 import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
 import com.moongeul.backend.api.member.service.FollowService;
@@ -155,6 +156,21 @@ public class MemberController {
     public ResponseEntity<ApiResponse<List<UserInfoDTO>>> getFollowers(@AuthenticationPrincipal UserDetails userDetails){
         List<UserInfoDTO> response = followService.getFollower(userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.GET_FOLLOWER_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "닉네임 재생성 API",
+            description = "랜덤 닉네임을 다시 생성하여 등록하고 바뀐 닉네임을 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 재생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
+    })
+    @PostMapping("/nickname/regenerate")
+    public ResponseEntity<ApiResponse<NicknameResponseDTO>> regenerateNickname(@AuthenticationPrincipal UserDetails userDetails) {
+
+        NicknameResponseDTO nicknameResponseDTO = memberService.regenerateNickname(userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.REGENERATE_NICKNAME_SUCCESS, nicknameResponseDTO);
     }
     
 }

--- a/src/main/java/com/moongeul/backend/api/member/dto/NicknameCheckResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/NicknameCheckResponseDTO.java
@@ -1,0 +1,15 @@
+package com.moongeul.backend.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NicknameCheckResponseDTO {
+    private Boolean isDuplicate; // 중복 여부
+}
+

--- a/src/main/java/com/moongeul/backend/api/member/dto/NicknameRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/NicknameRequestDTO.java
@@ -1,0 +1,20 @@
+package com.moongeul.backend.api.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NicknameRequestDTO {
+    
+    @NotBlank(message = "닉네임은 필수입니다")
+    @Size(min = 1, max = 12, message = "닉네임은 1자 이상 12자 이하여야 합니다")
+    private String nickname;
+}
+

--- a/src/main/java/com/moongeul/backend/api/member/dto/NicknameResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/NicknameResponseDTO.java
@@ -1,0 +1,15 @@
+package com.moongeul.backend.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NicknameResponseDTO {
+    private String nickname;
+}
+

--- a/src/main/java/com/moongeul/backend/api/member/entity/Member.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/Member.java
@@ -69,4 +69,11 @@ public class Member extends BaseTimeEntity {
     public void updateReadingTasteType(ReadingTasteType readingTasteType) {
         this.readingTasteType = readingTasteType;
     }
+
+    /**
+     * 닉네임 업데이트
+     */
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -7,6 +7,7 @@ import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.api.member.util.NicknameGenerator;
 import com.moongeul.backend.common.config.jwt.JwtTokenProvider;
+import com.moongeul.backend.common.exception.BadRequestException;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.exception.UnauthorizedException;
 import com.moongeul.backend.common.response.ErrorStatus;
@@ -163,6 +164,36 @@ public class MemberService {
 
         return NicknameResponseDTO.builder()
                 .nickname(newNickname)
+                .build();
+    }
+
+    // 닉네임 직접 등록
+    @Transactional
+    public NicknameResponseDTO updateNickname(String email, NicknameRequestDTO nicknameRequestDTO) {
+        Member member = getMemberByEmail(email);
+
+        String nickname = nicknameRequestDTO.getNickname();
+
+        // 닉네임 중복 체크
+        if (memberRepository.findByNickname(nickname).isPresent()) {
+            throw new BadRequestException(ErrorStatus.NICKNAME_ALREADY_EXISTS_EXCEPTION.getMessage());
+        }
+
+        // 닉네임 업데이트
+        member.updateNickname(nickname);
+
+        return NicknameResponseDTO.builder()
+                .nickname(nickname)
+                .build();
+    }
+
+    // 닉네임 중복 체크
+    @Transactional(readOnly = true)
+    public NicknameCheckResponseDTO checkNicknameDuplicate(String nickname) {
+        boolean isDuplicate = memberRepository.findByNickname(nickname).isPresent();
+
+        return NicknameCheckResponseDTO.builder()
+                .isDuplicate(isDuplicate)
                 .build();
     }
 }

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -149,4 +149,20 @@ public class MemberService {
         // 5. 재발급 토큰 반환
         return jwtToken;
     }
+
+    // 닉네임 재생성
+    @Transactional
+    public NicknameResponseDTO regenerateNickname(String email) {
+        Member member = getMemberByEmail(email);
+
+        // 랜덤 닉네임 생성
+        String newNickname = nicknameGenerator.generateUniqueNickname();
+
+        // 닉네임 업데이트
+        member.updateNickname(newNickname);
+
+        return NicknameResponseDTO.builder()
+                .nickname(newNickname)
+                .build();
+    }
 }

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -48,6 +48,7 @@ public enum ErrorStatus {
      */
     BOOK_ALREADY_ADDED_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 읽고 싶은 책으로 등록된 도서입니다."),
     REVIEW_ALREADY_EXISTS_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 리뷰를 작성한 도서입니다."),
+    NICKNAME_ALREADY_EXISTS_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
     SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자기 자신은 팔로우할 수 없습니다."),
 
     /**

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -22,6 +22,7 @@ public enum SuccessStatus {
 	FOLLOW_SUCCESS(HttpStatus.OK, "팔로우 성공"),
 	GET_FOLLOWING_SUCCESS(HttpStatus.OK, "팔로잉 목록 조회 성공"),
 	GET_FOLLOWER_SUCCESS(HttpStatus.OK, "팔로워 목록 조회 성공"),
+	REGENERATE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 재생성 성공"),
 
 	/* BOOK */
 	SEARCH_BOOK_SUCCESS(HttpStatus.OK, "도서 검색 성공"),

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -23,6 +23,8 @@ public enum SuccessStatus {
 	GET_FOLLOWING_SUCCESS(HttpStatus.OK, "팔로잉 목록 조회 성공"),
 	GET_FOLLOWER_SUCCESS(HttpStatus.OK, "팔로워 목록 조회 성공"),
 	REGENERATE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 재생성 성공"),
+	UPDATE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 등록 성공"),
+	CHECK_NICKNAME_DUPLICATE_SUCCESS(HttpStatus.OK, "닉네임 중복 체크 성공"),
 
 	/* BOOK */
 	SEARCH_BOOK_SUCCESS(HttpStatus.OK, "도서 검색 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #42

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기존에 생성된 사용자 랜덤 닉네임을 재생성 하는 기능을 구현하였습니다.
- 사용자가 원하는 닉네임을 직접 등록할 수 있는 기능을 구현하였습니다.
- 수동으로 닉네임을 등록할때 기존에 존재하는 닉네임인지 체크하는 기능을 구현하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->

[랜덤 닉네임 등록]
<img width="1434" height="54" alt="image" src="https://github.com/user-attachments/assets/a4385ee3-2371-4beb-8be7-7e023e76e729" />

[수동 닉네임 등록]
<img width="1434" height="54" alt="image" src="https://github.com/user-attachments/assets/335cc3fe-e896-49dd-96e9-5c3666f18a60" />

[닉네임 중복 체크]
<img width="1434" height="54" alt="image" src="https://github.com/user-attachments/assets/6bbe8c1b-e142-4c68-a899-6dd3c1ba2afc" />

