### PR TITLE
[FEAT] 주간 책 추천 기록 조회

### DIFF
--- a/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
+++ b/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
@@ -156,4 +156,20 @@ public class PostController {
         postService.likePost(id, userDetails.getUsername(), likeDTO);
         return ApiResponse.success_only(SuccessStatus.POST_LIKE_SUCCESS);
     }
+
+    @Operation(
+            summary = "주간 추천 기록 조회 API",
+            description = "같은 취향을 가진 사용자 중에서 최근 1주일 내 가장 공감을 많이 받은 기록을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "주간 추천 기록 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "주간 추천 기록을 찾을 수 없습니다.")
+    })
+    @GetMapping("/weekly-recommendation")
+    public ResponseEntity<ApiResponse<WeeklyRecommendationResponseDTO>> getWeeklyRecommendation(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        WeeklyRecommendationResponseDTO weeklyRecommendationResponseDTO = postService.getWeeklyRecommendation(userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.GET_WEEKLY_RECOMMENDATION_SUCCESS, weeklyRecommendationResponseDTO);
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/post/dto/WeeklyRecommendationResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/WeeklyRecommendationResponseDTO.java
@@ -1,0 +1,22 @@
+package com.moongeul.backend.api.post.dto;
+
+import com.moongeul.backend.api.member.entity.ReadingTasteType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeeklyRecommendationResponseDTO {
+    private Long postId; // 기록 ID
+    private String bookImage; // 책 사진
+    private String authorName; // 해당 기록을 작성한 사용자 이름
+    private String profileImage; // 프로필 사진
+    private Double rating; // 평점
+    private String content; // 기록글
+    private ReadingTasteType readingTasteType; // 로그인한 사용자의 책 취향
+}
+

--- a/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
@@ -26,12 +26,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "OR p.member = :member")
     Page<Post> findAllByFollower(@Param("member") Member member, Pageable pageable);
 
-    // 같은 취향 사용자들의 기록 중 최근 1주일 내 가장 공감을 많이 받은 기록 조회 (전체 조회 후 정렬)
+    // 같은 취향 사용자들의 기록 중 이번 주 가장 공감을 많이 받은 기록 조회
+    // 모든 공감 유형의 합계(relatableCount + sameTasteCount + impressiveExpressionCount + wantToReadCount + helpfulCount) 기준으로 정렬
     @Query("SELECT p FROM Post p " +
             "WHERE p.member.readingTasteType = :readingTasteType " +
-            "AND p.createdAt >= :oneWeekAgo " +
-            "ORDER BY p.relatableCount DESC, p.createdAt DESC")
+            "AND p.createdAt >= :weekStart " +
+            "ORDER BY (p.relatableCount + p.sameTasteCount + p.impressiveExpressionCount + p.wantToReadCount + p.helpfulCount) DESC, p.createdAt DESC")
     List<Post> findWeeklyRecommendationByReadingTasteType(
             @Param("readingTasteType") ReadingTasteType readingTasteType,
-            @Param("oneWeekAgo") LocalDateTime oneWeekAgo);
+            @Param("weekStart") LocalDateTime weekStart);
 }

--- a/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
@@ -2,12 +2,17 @@ package com.moongeul.backend.api.post.repository;
 
 import com.moongeul.backend.api.book.entity.Book;
 import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.entity.ReadingTasteType;
 import com.moongeul.backend.api.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     
@@ -20,4 +25,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "WHERE p.member IN (SELECT f.following FROM Follow f WHERE f.follower = :member) " +
             "OR p.member = :member")
     Page<Post> findAllByFollower(@Param("member") Member member, Pageable pageable);
+
+    // 같은 취향 사용자들의 기록 중 최근 1주일 내 가장 공감을 많이 받은 기록 조회 (전체 조회 후 정렬)
+    @Query("SELECT p FROM Post p " +
+            "WHERE p.member.readingTasteType = :readingTasteType " +
+            "AND p.createdAt >= :oneWeekAgo " +
+            "ORDER BY p.relatableCount DESC, p.createdAt DESC")
+    List<Post> findWeeklyRecommendationByReadingTasteType(
+            @Param("readingTasteType") ReadingTasteType readingTasteType,
+            @Param("oneWeekAgo") LocalDateTime oneWeekAgo);
 }

--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -347,5 +348,44 @@ public class PostService {
     private Category getCategory(Long categoryId) {
         return categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage()));
+    }
+
+    // 주간 추천 기록 조회
+    @Transactional(readOnly = true)
+    public WeeklyRecommendationResponseDTO getWeeklyRecommendation(String email) {
+        Member member = getMemberByEmail(email);
+        
+        // 사용자의 독서 취향이 없으면 예외 처리
+        if (member.getReadingTasteType() == null) {
+            throw new NotFoundException(ErrorStatus.USER_READING_TASTE_NOT_FOUND_EXCEPTION.getMessage());
+        }
+
+        // 최근 1주일 전 날짜 계산
+        LocalDateTime oneWeekAgo = LocalDateTime.now().minusWeeks(1);
+
+        // 같은 취향 사용자들의 기록 중 최근 1주일 내 가장 공감을 많이 받은 기록 조회
+        // 전체 기록을 조회한 후 정렬하여 가장 공감을 많이 받은 기록 선택
+        List<Post> recommendedPosts = postRepository.findWeeklyRecommendationByReadingTasteType(
+                member.getReadingTasteType(),
+                oneWeekAgo
+        );
+
+        // 추천 기록이 없으면 예외 처리
+        if (recommendedPosts.isEmpty()) {
+            throw new NotFoundException(ErrorStatus.WEEKLY_RECOMMENDATION_NOT_FOUND_EXCEPTION.getMessage());
+        }
+
+        // 가장 공감을 많이 받은 기록 (첫 번째 요소 - ORDER BY로 정렬된 결과)
+        Post post = recommendedPosts.get(0);
+
+        return WeeklyRecommendationResponseDTO.builder()
+                .postId(post.getId())
+                .bookImage(post.getBook().getBookImage())
+                .authorName(post.getMember().getName())
+                .profileImage(post.getMember().getProfileImage())
+                .rating(post.getRating())
+                .content(post.getContent())
+                .readingTasteType(member.getReadingTasteType())
+                .build();
     }
 }

--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -25,7 +25,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -360,14 +363,16 @@ public class PostService {
             throw new NotFoundException(ErrorStatus.USER_READING_TASTE_NOT_FOUND_EXCEPTION.getMessage());
         }
 
-        // 최근 1주일 전 날짜 계산
-        LocalDateTime oneWeekAgo = LocalDateTime.now().minusWeeks(1);
+        // 이번 주 월요일 00:00:00부터 오늘까지 계산
+        LocalDate today = LocalDate.now();
+        LocalDate thisWeekMonday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDateTime weekStart = thisWeekMonday.atStartOfDay();
 
-        // 같은 취향 사용자들의 기록 중 최근 1주일 내 가장 공감을 많이 받은 기록 조회
+        // 같은 취향 사용자들의 기록 중 이번 주(월요일~오늘) 가장 공감을 많이 받은 기록 조회
         // 전체 기록을 조회한 후 정렬하여 가장 공감을 많이 받은 기록 선택
         List<Post> recommendedPosts = postRepository.findWeeklyRecommendationByReadingTasteType(
                 member.getReadingTasteType(),
-                oneWeekAgo
+                weekStart
         );
 
         // 추천 기록이 없으면 예외 처리

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -42,6 +42,8 @@ public enum ErrorStatus {
     POST_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 기록(게시글)을 찾을 수 없습니다."),
     CATEGORY_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
     REVIEW_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 리뷰를 찾을 수 없습니다."),
+    USER_READING_TASTE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "사용자의 독서 취향 정보를 찾을 수 없습니다."),
+    WEEKLY_RECOMMENDATION_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "주간 추천 기록을 찾을 수 없습니다."),
 
     /**
      * 400 BAD_REQUEST

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -43,6 +43,7 @@ public enum SuccessStatus {
 	UPDATE_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 수정 성공"),
 	DELETE_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 삭제 성공"),
 	POST_LIKE_SUCCESS(HttpStatus.OK, "기록(게시글) 공감 버튼 등록 성공"),
+	GET_WEEKLY_RECOMMENDATION_SUCCESS(HttpStatus.OK, "주간 추천 기록 조회 성공"),
 
 	/* CATEGORY */
 	GET_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 전체 조회 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #44

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 주간 책 추천 기록 조회 기능을 구현하였습니다

[선별 조건]
1. 로그인 한 사용자와 같은 책 취향을 가지고 있는 대상
2. 이번 주: 이번 주 시작일(월요일)부터 오늘까지 등록된 기록 대상
3. 모든 공감 유형의 합계(relatableCount + sameTasteCount + impressiveExpressionCount + wantToReadCount + helpfulCount) 기준으로 정렬 후 제일 많은 합계를 받은 기록을 선별

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[주간 추천 기록 조회]
<img width="1429" height="783" alt="image" src="https://github.com/user-attachments/assets/83c63316-e0ec-4112-b62e-c59f18fca4f6" />
