### PR TITLE
[FEAT] 푸시 알림 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 .vscode/
 
 *.yml
+
+src/main/resources/

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Firebase Admin SDK: 서버 측에서 FCM, 인증 등을 제어할 수 있게 해주는 라이브러리
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/moongeul/backend/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/moongeul/backend/api/notification/controller/NotificationController.java
@@ -1,0 +1,43 @@
+package com.moongeul.backend.api.notification.controller;
+
+import com.moongeul.backend.api.notification.dto.DeviceTokenRequestDTO;
+import com.moongeul.backend.api.notification.service.NotificationService;
+import com.moongeul.backend.common.response.ApiResponse;
+import com.moongeul.backend.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Notification", description = "Notification(푸시알람) 관련 API 입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/notification")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @Operation(
+            summary = "사용자 기기 토큰 등록 API",
+            description = "현재 로그인한 사용자의 기기 토큰을 DB에 저장하거나, 이미 있다면 최신 상태로 업데이트합니다." +
+                    "<br><br>[enum] 토큰 플랫폼 유형 ->" +
+                    "<br>- ANDROID: 안드로이드" +
+                    "<br>- IOS: ios" +
+                    "<br>- WEB: 웹"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용자 기기 토큰 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다."),
+    })
+    @PostMapping("/device-token")
+    public ResponseEntity<ApiResponse<Void>> registerToken(@AuthenticationPrincipal UserDetails userDetails,
+                                                           @RequestBody DeviceTokenRequestDTO requestDTO) {
+        notificationService.registerOrUpdateToken(userDetails.getUsername(), requestDTO);
+
+        return ApiResponse.success_only(SuccessStatus.REGISTER_DEVICE_TOKEN);
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/notification/dto/DeviceTokenRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/notification/dto/DeviceTokenRequestDTO.java
@@ -1,0 +1,16 @@
+package com.moongeul.backend.api.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeviceTokenRequestDTO {
+
+    private String token;
+    private String platform; // 'ANDROID' or 'IOS' or 'WEB'
+}

--- a/src/main/java/com/moongeul/backend/api/notification/entity/DeviceToken.java
+++ b/src/main/java/com/moongeul/backend/api/notification/entity/DeviceToken.java
@@ -1,0 +1,34 @@
+package com.moongeul.backend.api.notification.entity;
+
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "device_token")
+public class DeviceToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 사용자 한 명당 여러 기기(토큰)를 가질 수 있으므로 1:N 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false, unique = true)
+    private String token; // FCM에서 발급받은 디바이스 토큰
+
+    private String platform; // Android 또는 iOS
+
+    // 토큰 주인 업데이트 로직
+    public void updateMember(Member member) {
+        this.member = member;
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/notification/entity/NotificationType.java
+++ b/src/main/java/com/moongeul/backend/api/notification/entity/NotificationType.java
@@ -1,0 +1,17 @@
+package com.moongeul.backend.api.notification.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+
+    NOTICE("서버공지"),
+    LIKE("공감 알림"),
+    COMMENT("댓글 알림"),
+    FOLLOW_OPEN("팔로우(공개 계정)"),
+    FOLLOW_PRIVATE("팔로우(비공개 계정)");
+
+    private final String key;
+}

--- a/src/main/java/com/moongeul/backend/api/notification/entity/Notifications.java
+++ b/src/main/java/com/moongeul/backend/api/notification/entity/Notifications.java
@@ -1,0 +1,36 @@
+package com.moongeul.backend.api.notification.entity;
+
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notifications")
+public class Notifications extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id")
+    private Member receiver; // 알림을 받는 사람
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "actor_id")
+    private Member actor;    // 알림 발생시킨 사람
+
+    private String content; // 알림 내용
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType type; // NOTICE, LIKE, COMMENT 등
+
+    private Long relatedId; // 클릭 시 이동할 게시글 ID or 유저 ID or 공지사항 ID
+
+    private boolean isRead; // 읽음 처리 여부
+}

--- a/src/main/java/com/moongeul/backend/api/notification/event/LikeNotificationEvent.java
+++ b/src/main/java/com/moongeul/backend/api/notification/event/LikeNotificationEvent.java
@@ -1,0 +1,11 @@
+package com.moongeul.backend.api.notification.event;
+
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.post.entity.Post;
+
+public record LikeNotificationEvent(
+
+    Member receiver, // 알림을 받을 사람 (게시글 작성자)
+    Member actor,    // 공감을 누른 사람
+    Post post        // 어떤 게시글인지
+) {}

--- a/src/main/java/com/moongeul/backend/api/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/moongeul/backend/api/notification/listener/NotificationEventListener.java
@@ -1,0 +1,31 @@
+package com.moongeul.backend.api.notification.listener;
+
+import com.moongeul.backend.api.notification.entity.NotificationType;
+import com.moongeul.backend.api.notification.event.LikeNotificationEvent;
+import com.moongeul.backend.api.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener { // 발행된 이벤트를 받아서 별도의 스레드에서 비동기적으로 알림을 저장하고 전송하는 클래스
+
+    private final NotificationService notificationService;
+
+    @Async // 별도의 스레드에서 실행되도록 설정
+    @EventListener // LikeNotificationEvent가 발행되면 호출됨
+    public void handleLikeNotification(LikeNotificationEvent event) {
+        String message = event.actor().getNickname() + "님이 회원님의 기록에 공감했습니다.";
+
+        // 실제 DB 저장 및 FCM 발송 로직 실행
+        notificationService.send(
+                event.receiver(),
+                event.actor(),
+                NotificationType.LIKE,
+                message,
+                event.post().getId()
+        );
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/moongeul/backend/api/notification/repository/DeviceTokenRepository.java
@@ -1,0 +1,18 @@
+package com.moongeul.backend.api.notification.repository;
+
+import com.moongeul.backend.api.notification.entity.DeviceToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+    // 특정 회원의 모든 기기 토큰 조회 (알림 보낼 때 필요)
+    List<DeviceToken> findAllByMemberId(Long memberId);
+
+    // 이미 존재하는 토큰인지 확인
+    Optional<DeviceToken> findByToken(String token);
+
+    // 로그아웃 시 특정 토큰 삭제
+    void deleteByToken(String token);
+}

--- a/src/main/java/com/moongeul/backend/api/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/moongeul/backend/api/notification/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.moongeul.backend.api.notification.repository;
+
+import com.moongeul.backend.api.notification.entity.Notifications;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notifications, Long> {
+
+}

--- a/src/main/java/com/moongeul/backend/api/notification/service/NotificationService.java
+++ b/src/main/java/com/moongeul/backend/api/notification/service/NotificationService.java
@@ -1,0 +1,92 @@
+package com.moongeul.backend.api.notification.service;
+
+import com.google.firebase.messaging.*;
+import com.moongeul.backend.api.notification.dto.DeviceTokenRequestDTO;
+import com.moongeul.backend.api.notification.entity.DeviceToken;
+import com.moongeul.backend.api.notification.entity.NotificationType;
+import com.moongeul.backend.api.notification.entity.Notifications;
+import com.moongeul.backend.api.notification.repository.DeviceTokenRepository;
+import com.moongeul.backend.api.notification.repository.NotificationRepository;
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.common.exception.NotFoundException;
+import com.moongeul.backend.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final MemberRepository memberRepository;
+    private final NotificationRepository notificationRepository;
+
+    /* 토큰 등록/수정 */
+    @Transactional
+    public void registerOrUpdateToken(String email, DeviceTokenRequestDTO requestDTO) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        deviceTokenRepository.findByToken(requestDTO.getToken())
+                .ifPresentOrElse(
+                        token -> token.updateMember(member),
+                        () -> deviceTokenRepository.save(DeviceToken.builder()
+                                .member(member)
+                                .token(requestDTO.getToken())
+                                .platform(requestDTO.getPlatform())
+                                .build())
+                );
+    }
+
+    @Transactional
+    public void send(Member receiver, Member actor, NotificationType notificationType, String message, Long relatedId) {
+        Notifications notifications = Notifications.builder()
+                .receiver(receiver)
+                .actor(actor)
+                .content(message)
+                .type(notificationType)
+                .relatedId(relatedId)
+                .isRead(false)
+                .build();
+        notificationRepository.save(notifications);
+
+        List<DeviceToken> tokens = deviceTokenRepository.findAllByMemberId(receiver.getId());
+
+        if (!tokens.isEmpty()) {
+            for (DeviceToken deviceToken : tokens) {
+                try {
+                    sendMessage(deviceToken.getToken(), notificationType.getKey(), message);
+                } catch (FirebaseMessagingException e) {
+                    if (e.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
+                        log.warn("유효하지 않은 토큰 삭제: {}", deviceToken.getToken());
+                        deviceTokenRepository.delete(deviceToken);
+                    } else {
+                        log.error("FCM 에러 발생: {}", e.getMessage());
+                    }
+                } catch (Exception e) {
+                    log.error("일반 전송 에러: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    /* 토큰을 가진 기기에 푸시 알림 전송 */
+    public void sendMessage(String targetToken, String title, String body) throws FirebaseMessagingException {
+        Message message = Message.builder()
+                .setToken(targetToken)
+                .setNotification(Notification.builder()
+                        .setTitle(title) // 알림 타입
+                        .setBody(body) // 알림 내용
+                        .build())
+                .build();
+
+        String response = FirebaseMessaging.getInstance().send(message); // 여기서 발생하는 에러가 위쪽(send 메서드)으로 전달
+        log.info("FCM 전송 성공: " + response);
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.moongeul.backend.api.post.service;
 
+import com.moongeul.backend.api.notification.event.LikeNotificationEvent;
 import com.moongeul.backend.api.book.entity.Book;
 import com.moongeul.backend.api.book.repository.BookRepository;
 import com.moongeul.backend.api.bookshelf.entity.DoneReadBookshelf;
@@ -19,6 +20,7 @@ import com.moongeul.backend.common.exception.UnauthorizedException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -46,7 +48,13 @@ public class PostService {
     private final QuoteRepository quoteRepository;
     private final DoneReadBookshelfRepository doneReadBookshelfRepository;
     private final BookshelfCalculator bookshelfCalculator;
+    
+    private final ApplicationEventPublisher eventPublisher; // Spring Event 발행 객체
 
+    /*
+     * 기록
+     */
+    
     /* 글쓰기 */
     @Transactional
     public PostIdResponseDTO createPost(PostRequestDTO postRequestDTO, String email){
@@ -274,6 +282,10 @@ public class PostService {
         }
     }
 
+    /*
+     * 공감
+     */
+
     /* 공감 토글 */
     @Transactional
     public void likePost(Long postId, String email, LikeDTO likeDTO){
@@ -298,14 +310,24 @@ public class PostService {
             decrementLikeCount(post, currentLikes.getLikeType());
             currentLikes.changeLikeType(likeDTO.getLikeType());
             incrementLikeCount(post, likeDTO.getLikeType());
+
+            likeNotification(post.getMember(), member, post); // 알림 발생
             return;
         }
         
         // 처음 공감을 누르는 경우 -> 새로 저장
         likeRepository.save(likeDTO.toEntity(member, post));
         incrementLikeCount(post, likeDTO.getLikeType());
+
+        likeNotification(post.getMember(), member, post); // 알림 발생
     }
 
+    private void likeNotification(Member receiver, Member actor, Post post){
+        if (!receiver.getId().equals(actor.getId())) { // 자신의 게시글일 경우 알림 발생 x
+            eventPublisher.publishEvent(new LikeNotificationEvent(receiver, actor, post));
+        }
+    }
+    
     // 공감 카운트 증가 메서드
     private void incrementLikeCount(Post post, LikeType likeType) {
         switch (likeType) {
@@ -328,31 +350,10 @@ public class PostService {
         }
     }
 
-
     /*
-    * 단순 데이터 불러오기용 코드 메서드 - 코드 깔끔하게 하기용
-    */
-
-    private Member getMemberByEmail(String email) {
-        return memberRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
-    }
-
-    private Book getBook(String isbn) {
-        return bookRepository.findByIsbn(isbn)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.BOOK_NOTFOUND_EXCEPTION.getMessage()));
-    }
-
-    private Post getPost(Long postId) {
-        return postRepository.findById(postId)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.POST_NOTFOUND_EXCEPTION.getMessage()));
-    }
-
-    private Category getCategory(Long categoryId) {
-        return categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage()));
-    }
-
+     * 추천
+     */
+    
     // 주간 추천 기록 조회
     @Transactional(readOnly = true)
     public WeeklyRecommendationResponseDTO getWeeklyRecommendation(String email) {
@@ -392,5 +393,29 @@ public class PostService {
                 .content(post.getContent())
                 .readingTasteType(member.getReadingTasteType())
                 .build();
+    }
+
+    /*
+     * 단순 데이터 불러오기용 코드 메서드 - 코드 깔끔하게 하기용
+     */
+
+    private Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    }
+
+    private Book getBook(String isbn) {
+        return bookRepository.findByIsbn(isbn)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.BOOK_NOTFOUND_EXCEPTION.getMessage()));
+    }
+
+    private Post getPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.POST_NOTFOUND_EXCEPTION.getMessage()));
+    }
+
+    private Category getCategory(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage()));
     }
 }

--- a/src/main/java/com/moongeul/backend/common/config/Async/AsyncConfig.java
+++ b/src/main/java/com/moongeul/backend/common/config/Async/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.moongeul.backend.common.config.Async;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync // 비동기 처리 활성화
+public class AsyncConfig {
+}

--- a/src/main/java/com/moongeul/backend/common/config/firebase/FirebaseConfig.java
+++ b/src/main/java/com/moongeul/backend/common/config/firebase/FirebaseConfig.java
@@ -1,0 +1,42 @@
+package com.moongeul.backend.common.config.firebase;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${fcm.certification}")
+    private String credentialPath;
+
+    @PostConstruct // 3. 의존성 주입이 완료된 후, 딱 한 번만 실행되도록 보장
+    public void initialize() {
+        try {
+            // 4. 리소스 폴더의 인증 파일을 읽어옴
+            ClassPathResource resource = new ClassPathResource(credentialPath);
+            InputStream inputStream = resource.getInputStream();
+
+            // 5. Firebase 옵션 설정 (인증 정보 세팅)
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(inputStream))
+                    .build();
+
+            // 6. FirebaseApp이 이미 초기화되어 있는지 확인 후 초기화 진행
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                System.out.println("FCM 초기화 성공");
+            }
+        } catch (IOException e) {
+            // 초기화 실패 시 서버 실행 시점에 에러를 파악할 수 있게 로깅함
+            System.err.println("FCM 초기화 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/moongeul/backend/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/moongeul/backend/common/config/security/SecurityConfig.java
@@ -32,8 +32,9 @@ public class SecurityConfig {
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable())) //h2-console 화면 깨짐 방지(iframe 렌더링 오류)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/h2-console/**").permitAll()
+                        .requestMatchers("/static/**", "/index.html", "/firebase-messaging-sw.js", "/favicon.ico").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/api-doc/**", "/swagger-ui/**").permitAll()
-                        .requestMatchers("/api/v2/member/google/login", "/api/v2/member/kakao/login", "api/v2/member/reissue-token").permitAll()
+                        .requestMatchers("/api/v2/member/google/login", "/api/v2/member/kakao/login", "/api/v2/member/reissue-token").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -51,6 +51,9 @@ public enum SuccessStatus {
 	/* CATEGORY */
 	GET_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 전체 조회 성공"),
 
+	/* ALARM */
+	REGISTER_DEVICE_TOKEN(HttpStatus.OK, "사용자 기기 토큰 등록 성공"),
+
 
 	/**
 	 * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #46 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
**실시간 FCM(Firebase Cloud Messaging) 푸시 알림 시스템을 구축하였습니다.**

**1. FCM 전송 엔진 및 예외 처리 (FcmService, NotificationService)**
- 전송 로직: Firebase Admin SDK를 사용하여 유저별 기기 토큰으로 알림을 전송합니다.
- 에러 핸들링: 전송 중 MessagingErrorCode.UNREGISTERED(유효하지 않은 토큰) 에러 발생 시, DB에서 즉시 삭제하여 전송 리소스를 최적화했습니다.

**2. 기기 토큰 관리 및 DB 설계 (DeviceToken)**
- 1:N 구조: 한 사용자가 여러 대의 기기(웹, 모바일 등)에서 알림을 받을 수 있도록 설계했습니다.
- Upsert 로직: 토큰 등록 시 기존 토큰이 존재하면 주인(Member) 정보를 갱신하고, 없으면 새로 생성합니다.

**3. CI/CD 보안 및 인프라 설정**
- 보안 강화: serviceAccountKey.json(Firebase-Key) 파일을 직접 커밋하지 않고, GitHub Secrets를 통해 배포 시점에 동적으로 생성하도록 deploy.yml을 구성했습니다.
- Spring Security: 서비스 워커 및 FCM 관련 정적 리소스 접근을 위해 보안 설정을 조정했습니다. (테스트를 위해 조정하였습니다. 참고로 테스트  html, js 는 커밋하지 않았습니다)

[전달 사항]
알림 비즈니스 로직은 기타 도메인의 메서드들이 구현된 후, 최종적으로 서비스 내부 알림 페이지 조회 API까지 구현하겠습니다.
현재는 fcm을 활용한 푸시 알림 시스템 틀을 구축하였습니다.
- 테스트를 위해 공감 버튼 시 알림이 전송되는 비즈니스 로직은 구현해두었습니다. 

[Message 데이터 구성]
```
Message message = Message.builder()
    .setToken(targetToken)
    .setNotification(Notification.builder()
            .setTitle(title)  // 알림 타입: 예) "공감 알림"
            .setBody(body)    // 알림 내용: 예) "(사용자)님이 회원님의 기록에 공감했습니다."
            .build())
    .build();
```

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[POST] /api/v2/notification/token
프론트엔드에서 발급받은 FCM 토큰을 서버에 등록/수정합니다.

<img width="918" height="621" alt="image" src="https://github.com/user-attachments/assets/35fd5c2d-715f-44ca-8586-a3e96f39d9dd" />

웹 알림
<img width="423" height="226" alt="image" src="https://github.com/user-attachments/assets/ce17ad08-8159-4bee-a584-84db0c1910d8" />
