### PR TITLE
[FIX] 팔로우 기능 수정 (+비공개 계정 팔로우 기능 추가)

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -1,11 +1,6 @@
 package com.moongeul.backend.api.member.controller;
 
-import com.moongeul.backend.api.member.dto.LoginResponseDTO;
-import com.moongeul.backend.api.member.dto.LoginRequestDTO;
-import com.moongeul.backend.api.member.dto.NicknameCheckResponseDTO;
-import com.moongeul.backend.api.member.dto.NicknameRequestDTO;
-import com.moongeul.backend.api.member.dto.NicknameResponseDTO;
-import com.moongeul.backend.api.member.dto.UserInfoDTO;
+import com.moongeul.backend.api.member.dto.*;
 import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
 import com.moongeul.backend.api.member.service.FollowService;
 import com.moongeul.backend.api.member.service.MemberService;
@@ -116,10 +111,8 @@ public class MemberController {
     *
     * */
     @Operation(
-            summary = "팔로우/언팔로우 API",
-            description = "사용자를 팔로우 또는 언팔로우 합니다." +
-                    "<br>- 팔로우하고 있는 사용자에게 해당 API를 한 번 더 사용 시, 팔로우가 취소됩니다." +
-                    "<br>- 즉, 팔로우/언팔로우 두 버튼에 모두 해당 API를 사용하시면 됩니다."
+            summary = "팔로우 API",
+            description = "사용자를 팔로우 합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "팔로우 성공"),
@@ -133,33 +126,63 @@ public class MemberController {
     }
 
     @Operation(
+            summary = "언팔로우(팔로우 취소) API",
+            description = "사용자를 언팔로우 합니다." +
+                    "<br>- '승인 대기중'일 때 해당 API 사용 시, 팔로우 요청 취소 됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "언팔로우 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
+    })
+    @PostMapping("/unfollow/{id}")
+    public ResponseEntity<ApiResponse<Void>> unfollow(@AuthenticationPrincipal UserDetails userDetails,
+                                                    @PathVariable Long id){
+        followService.unfollow(id, userDetails.getUsername());
+        return ApiResponse.success_only(SuccessStatus.UNFOLLOW_SUCCESS);
+    }
+
+    @Operation(
             summary = "팔로잉 사용자 목록 조회 API",
-            description = "내가 팔로우한 사용자(팔로잉)의 목록을 조회합니다."
+            description = "내가 팔로우한 사용자(팔로잉)의 목록을 조회합니다." +
+                    "<br><br>[enum] myFollowStatus: 내가 해당 팔로워를 팔로우했는지 확인하는 필드:" +
+                    "<br>- NONE: 팔로우 아님" +
+                    "<br>- PENDING: 요청 대기중" +
+                    "<br>- ACCEPTED: 팔로우 완료" +
+                    "<br>- *참고: 해당 목록은 모두 ACCEPTED 입니다. (팔로우한 사용자들이기 때문에)"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "팔로잉 목록 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
     })
     @GetMapping("/following")
-    public ResponseEntity<ApiResponse<List<UserInfoDTO>>> getFollowings(@AuthenticationPrincipal UserDetails userDetails){
-        List<UserInfoDTO> response = followService.getFollowing(userDetails.getUsername());
+    public ResponseEntity<ApiResponse<List<FollowResponseDTO>>> getFollowings(@AuthenticationPrincipal UserDetails userDetails){
+        List<FollowResponseDTO> response = followService.getFollowing(userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.GET_FOLLOWING_SUCCESS, response);
     }
 
     @Operation(
             summary = "팔로워 사용자 목록 조회 API",
-            description = "나를 팔로잉한 사용자(팔로워)의 목록을 조회합니다."
+            description = "나를 팔로잉한 사용자(팔로워)의 목록을 조회합니다." +
+                    "<br><br>[enum] myFollowStatus: 내가 해당 팔로워를 팔로우했는지 확인하는 필드:" +
+                    "<br>- NONE: 팔로우 아님" +
+                    "<br>- PENDING: 요청 대기중" +
+                    "<br>- ACCEPTED: 팔로우 완료"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "팔로워 목록 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
     })
     @GetMapping("/follower")
-    public ResponseEntity<ApiResponse<List<UserInfoDTO>>> getFollowers(@AuthenticationPrincipal UserDetails userDetails){
-        List<UserInfoDTO> response = followService.getFollower(userDetails.getUsername());
+    public ResponseEntity<ApiResponse<List<FollowResponseDTO>>> getFollowers(@AuthenticationPrincipal UserDetails userDetails){
+        List<FollowResponseDTO> response = followService.getFollower(userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.GET_FOLLOWER_SUCCESS, response);
     }
 
+    /*
+     *
+     * 닉네임 API
+     *
+     * */
     @Operation(
             summary = "랜덤 닉네임 재생성 API",
             description = "랜덤 닉네임을 다시 생성하여 등록하고 바뀐 닉네임을 반환합니다."

--- a/src/main/java/com/moongeul/backend/api/member/dto/FollowResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/FollowResponseDTO.java
@@ -1,0 +1,17 @@
+package com.moongeul.backend.api.member.dto;
+
+import com.moongeul.backend.api.member.entity.FollowStatus;
+import com.moongeul.backend.api.member.entity.ReadingTasteType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FollowResponseDTO {
+
+    private final Long id;
+    private final String profileImage;
+    private final String nickname;
+    private final ReadingTasteType readingTasteType;
+    private final FollowStatus myFollowStatus;
+}

--- a/src/main/java/com/moongeul/backend/api/member/entity/Follow.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/Follow.java
@@ -21,10 +21,17 @@ public class Follow extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "following_id", nullable = false)
-    private Member following;
+    private Member following; // 팔로우 대상
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follower_id", nullable = false)
-    private Member follower;
+    private Member follower; // 팔로우를 신청한 사람
 
+    @Enumerated(EnumType.STRING)
+    private FollowStatus followStatus; // 팔로우 승인 상태
+
+    // 상태 변경 (승인 시 사용)
+    public void accept() {
+        this.followStatus = FollowStatus.ACCEPTED;
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/member/entity/FollowStatus.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/FollowStatus.java
@@ -1,0 +1,15 @@
+package com.moongeul.backend.api.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FollowStatus {
+
+    NONE("팔로우 아님"),
+    PENDING("요청 대기중"),
+    ACCEPTED("팔로우 완료");
+
+    private final String key;
+}

--- a/src/main/java/com/moongeul/backend/api/member/entity/Member.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/Member.java
@@ -30,6 +30,9 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ReadingTasteType readingTasteType; // 독서 취향 유형
 
+    @Enumerated(EnumType.STRING)
+    private PrivacyLevel privacyLevel = PrivacyLevel.PUBLIC; // 기본값: 전체공개
+
     @Column(unique = true)
     private String socialId; // 소셜 로그인 ID (고유값)
     
@@ -75,5 +78,12 @@ public class Member extends BaseTimeEntity {
      */
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    /**
+     * 공개 범위 변경 메서드
+     */
+    public void updatePrivacy(PrivacyLevel level) {
+        this.privacyLevel = level;
     }
 }

--- a/src/main/java/com/moongeul/backend/api/member/entity/PrivacyLevel.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/PrivacyLevel.java
@@ -1,0 +1,15 @@
+package com.moongeul.backend.api.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PrivacyLevel {
+
+    PUBLIC("전체공개"),
+    FOLLOWER_ONLY("팔로워에게만 일부 공개"),
+    PRIVATE("비공개");
+
+    private final String key;
+}

--- a/src/main/java/com/moongeul/backend/api/member/repository/FollowRepository.java
+++ b/src/main/java/com/moongeul/backend/api/member/repository/FollowRepository.java
@@ -10,11 +10,20 @@ import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
+    // 1. 특정 관계 조회
     Optional<Follow> findByFollowingIdAndFollowerId(Long followingId, Long followerId);
 
-    @Query("select f from Follow f join fetch f.following where f.follower.id = :followerId")
+    // 2. 팔로잉 목록: 내가 팔로우한 사람들 중 '승인 완료(ACCEPTED)'인 경우만 조회
+    @Query("select f from Follow f join fetch f.following " +
+            "where f.follower.id = :followerId and f.followStatus = 'ACCEPTED'")
     List<Follow> findByFollowings(@Param("followerId") Long followerId);
 
-    @Query("select f from Follow f join fetch f.follower where f.following.id = :followingId")
+    // 3. 팔로워 목록: 나를 팔로우하는 사람들 중 '승인 완료(ACCEPTED)'인 경우만 조회
+    @Query("select f from Follow f join fetch f.follower " +
+            "where f.following.id = :followingId and f.followStatus = 'ACCEPTED'")
     List<Follow> findByFollowers(@Param("followingId") Long followingId);
+
+    // 4. 내가 팔로우를 건 모든 기록 (상태 상관 x)
+    // 팔로워 목록에서 '내가 그들에게 보낸 상태'를 확인하기 위해 필요
+    List<Follow> findAllByFollowerId(Long followerId);
 }

--- a/src/main/java/com/moongeul/backend/api/member/service/FollowService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/FollowService.java
@@ -1,9 +1,11 @@
 package com.moongeul.backend.api.member.service;
 
 
-import com.moongeul.backend.api.member.dto.UserInfoDTO;
+import com.moongeul.backend.api.member.dto.FollowResponseDTO;
 import com.moongeul.backend.api.member.entity.Follow;
+import com.moongeul.backend.api.member.entity.FollowStatus;
 import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.entity.PrivacyLevel;
 import com.moongeul.backend.api.member.repository.FollowRepository;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.common.exception.BadRequestException;
@@ -15,7 +17,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -25,48 +28,66 @@ public class FollowService {
     private final FollowRepository followRepository;
     private final MemberRepository memberRepository;
 
-    // 팔로우/언팔로우
+    /* 팔로우 API */
     @Transactional
     public void follow(Long following_id, String email){
-        Member following_member = getById(following_id);
-        Member follower_member = getMemberByEmail(email);
+        Member following = getById(following_id); // 팔로우 대상
+        Member follower = getMemberByEmail(email); // 나
 
         // 에러처리: 자기자신을 팔로우하는 경우 (불가)
-        if(following_member.equals(follower_member)){
+        if(following.equals(follower)){
             throw new BadRequestException(ErrorStatus.SELF_FOLLOW_NOT_ALLOWED.getMessage());
         }
 
-        Optional<Follow> existingFollow = followRepository.findByFollowingIdAndFollowerId(following_member.getId(), follower_member.getId());
+        // 에러처리: 이미 팔로우 중이거나 요청 대기 중인 경우
+        followRepository.findByFollowingIdAndFollowerId(following.getId(), follower.getId())
+                .ifPresent(follow -> {
+                    if (follow.getFollowStatus() == FollowStatus.ACCEPTED) {
+                        throw new BadRequestException(ErrorStatus.EXISTS_FOLLOW_ACCEPTED.getMessage());
+                    } else if (follow.getFollowStatus() == FollowStatus.PENDING) {
+                        throw new BadRequestException(ErrorStatus.EXISTS_FOLLOW_PENDING.getMessage());
+                    }
+                });
 
-        // 이미 팔로우하고 있는 사용자라면 -> 팔로우 취소
-        if(existingFollow.isPresent()){
-            Follow currentFollow = existingFollow.get();
-            followRepository.delete(currentFollow);
-        } else{ // 처음 팔로우 -> 팔로우 성공
-            Follow new_follow = Follow.builder()
-                    .following(following_member)
-                    .follower(follower_member)
-                    .build();
+        // 상대방이 공개/일부공개/비공개 계정인지 확인하여 상태 결정
+        FollowStatus status = following.getPrivacyLevel() == PrivacyLevel.PUBLIC ? FollowStatus.ACCEPTED : FollowStatus.PENDING;
 
-            followRepository.save(new_follow);
-        }
+        Follow newFollow = Follow.builder()
+                .follower(follower)
+                .following(following)
+                .followStatus(status)
+                .build();
+
+        followRepository.save(newFollow);
     }
 
-    // 팔로잉 사용자 목록 조회 // 생성, 수정, 삭제가 없는 메서드
-    @Transactional(readOnly = true)
-    public List<UserInfoDTO> getFollowing(String email){
-        Member follower_member = getMemberByEmail(email);
+    /* 언팔로우 API - 이 경우, 승인 대기중 상태도 같이 삭제 */
+    @Transactional
+    public void unfollow(Long followingId, String email) {
+        Member follower = getMemberByEmail(email); // 나
 
-        return followRepository.findByFollowings(follower_member.getId())
+        // 예외처리: 팔로우 관계가 존재하지 않는 경우
+        Follow follow = followRepository.findByFollowingIdAndFollowerId(followingId, follower.getId())
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.NO_FOLLOW_RELATIONSHIP.getMessage()));
+
+        followRepository.delete(follow);
+    }
+
+    // 팔로잉 사용자 목록 조회
+    @Transactional(readOnly = true) // 생성, 수정, 삭제가 없는 메서드
+    public List<FollowResponseDTO> getFollowing(String email){
+        Member me = getMemberByEmail(email);
+
+        return followRepository.findByFollowings(me.getId())
                 .stream()
                 .map(follow -> {
                     Member following = follow.getFollowing();
-                    return UserInfoDTO.builder()
+                    return FollowResponseDTO.builder()
                             .id(following.getId())
-                            .name(following.getName())
                             .profileImage(following.getProfileImage())
                             .nickname(following.getNickname())
                             .readingTasteType(following.getReadingTasteType())
+                            .myFollowStatus(FollowStatus.ACCEPTED)
                             .build();
                 })
                 .toList();
@@ -74,19 +95,34 @@ public class FollowService {
 
     // 팔로워 사용자 목록 조회
     @Transactional(readOnly = true) // 생성, 수정, 삭제가 없는 메서드
-    public List<UserInfoDTO> getFollower(String email){
-        Member following_member = getMemberByEmail(email);
+    public List<FollowResponseDTO> getFollower(String email){
+        Member me = getMemberByEmail(email);
 
-        return followRepository.findByFollowers(following_member.getId())
+        // 나를 팔로우하는 사람들(Follower) 목록 조회 (상태: ACCEPTED만)
+        List<Follow> followers = followRepository.findByFollowers(me.getId());
+
+        // 내가 누구를 팔로우하고 있는지(PENDING, ACCEPTED) 전체 목록을 Map으로 만듦
+        // Map은 서비스 로직 안에서만 '검색용'으로 쓰임
+        Map<Long, FollowStatus> myFollowStatusMap = followRepository.findAllByFollowerId(me.getId())
                 .stream()
+                .collect(Collectors.toMap(
+                        follow -> follow.getFollowing().getId(), // Key: 상대방 ID
+                        follow -> follow.getFollowStatus()       // Value: 나의 팔로우 상태
+                ));
+
+        return followers.stream()
                 .map(follow -> {
-                    Member follower = follow.getFollower();
-                    return UserInfoDTO.builder()
-                            .id(follower.getId())
-                            .name(follower.getName())
-                            .profileImage(follower.getProfileImage())
-                            .nickname(follower.getNickname())
-                            .readingTasteType(follower.getReadingTasteType())
+                    Member target = follow.getFollower(); // 나를 팔로우한 그 사람
+
+                    // Map에서 내가 이 사람을 팔로우 중인지 찾음, 없으면 NONE!
+                    FollowStatus status = myFollowStatusMap.getOrDefault(target.getId(), FollowStatus.NONE);
+
+                    return FollowResponseDTO.builder()
+                            .id(target.getId())
+                            .profileImage(target.getProfileImage())
+                            .nickname(target.getNickname())
+                            .readingTasteType(target.getReadingTasteType())
+                            .myFollowStatus(status) // 결정된 상태값(NONE, PENDING, ACCEPTED) 주입
                             .build();
                 })
                 .toList();

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.moongeul.backend.api.member.service;
 
 import com.moongeul.backend.api.member.dto.*;
 import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.entity.PrivacyLevel;
 import com.moongeul.backend.api.member.entity.Role;
 import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
 import com.moongeul.backend.api.member.repository.MemberRepository;
@@ -101,6 +102,7 @@ public class MemberService {
                 .profileImage(picture)
                 .nickname(nickname)
                 .password("OAuth Password") // 임시 패스워드
+                .privacyLevel(PrivacyLevel.PUBLIC) // 기본값: 전체공개
                 .socialId(socialId)
                 .socialType(socialType)
                 .role(Role.GUEST) // 이후 필요 정보 모두 입력 시 USER 로 승격

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -52,6 +52,9 @@ public enum ErrorStatus {
     REVIEW_ALREADY_EXISTS_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 리뷰를 작성한 도서입니다."),
     NICKNAME_ALREADY_EXISTS_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
     SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자기 자신은 팔로우할 수 없습니다."),
+    NO_FOLLOW_RELATIONSHIP(HttpStatus.BAD_REQUEST, "팔로우 관계가 존재하지 않습니다."),
+    EXISTS_FOLLOW_ACCEPTED(HttpStatus.BAD_REQUEST, "이미 팔로우하고 있는 사용자입니다."),
+    EXISTS_FOLLOW_PENDING(HttpStatus.BAD_REQUEST, "이미 팔로우 요청을 보냈습니다. 승인을 기다려주세요."),
 
     /**
      * 500 SERVER_ERROR

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -20,6 +20,7 @@ public enum SuccessStatus {
 	REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
 	CALCULATE_READING_TASTE_SUCCESS(HttpStatus.OK, "독서 취향 테스트 결과 계산 성공"),
 	FOLLOW_SUCCESS(HttpStatus.OK, "팔로우 성공"),
+	UNFOLLOW_SUCCESS(HttpStatus.OK, "언팔로우 성공"),
 	GET_FOLLOWING_SUCCESS(HttpStatus.OK, "팔로잉 목록 조회 성공"),
 	GET_FOLLOWER_SUCCESS(HttpStatus.OK, "팔로워 목록 조회 성공"),
 	REGENERATE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 재생성 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #48 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
1. 비공개 계정에 대한 팔로우 기능을 추가합니다.
- 공개 계정의 경우, 바로 팔로우 가능
- 비공개 계정의 경우, 팔로우 요청 시 -> 요청 대기중 -> 승인 -> 팔로우 완료
- 팔로워 목록 조회 API 수정

2. 나의 팔로워 목록에 '내가 그들을 팔로우 하고 있는지'를 알 수 있는 'myFollow' 필드를 추가합니다.
- myFollow -> 팔로우O / 요청 대기중 / 팔로우X

3. 팔로우 | 언팔로우 API 분리
- 기존 동일하게 사용했던 API를 분리하였습니다.
- '요청 대기중' 팔로우 요청도 언팔로우 API 사용 시, 삭제 가능합니다! (취소 처리로 여겨짐)

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="662" height="250" alt="image" src="https://github.com/user-attachments/assets/3a2aeba7-38a5-4e8a-a558-3eb7f260a8e0" />

<img width="1063" height="464" alt="image" src="https://github.com/user-attachments/assets/84649aea-7a2f-47c6-8081-544b300923da" />
