### PR TITLE
[FEAT] 질문/답변 수정, 삭제, 조회 API 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/question/controller/AnswerController.java
+++ b/src/main/java/com/moongeul/backend/api/question/controller/AnswerController.java
@@ -1,0 +1,46 @@
+package com.moongeul.backend.api.question.controller;
+
+import com.moongeul.backend.api.question.dto.AnswerCreateRequestDTO;
+import com.moongeul.backend.api.question.dto.AnswerIdResponseDTO;
+import com.moongeul.backend.api.question.service.AnswerService;
+import com.moongeul.backend.common.response.ApiResponse;
+import com.moongeul.backend.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Answer", description = "Answer(답변) 관련 API 입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/answer")
+public class AnswerController {
+
+    private final AnswerService answerService;
+
+    @Operation(
+            summary = "답변 생성 API",
+            description = "질문에 대한 답변을 생성하는 API 입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "답변 생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "답변 내용은 필수입니다 / 질문 ID는 필수입니다"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 질문을 찾을 수 없습니다 / 사용자를 찾을 수 없습니다")
+    })
+    @PostMapping("/create")
+    public ResponseEntity<ApiResponse<AnswerIdResponseDTO>> createAnswer(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody AnswerCreateRequestDTO answerCreateRequestDTO) {
+
+        AnswerIdResponseDTO answerIdResponseDTO = answerService.createAnswer(answerCreateRequestDTO, userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.CREATE_ANSWER_SUCCESS, answerIdResponseDTO);
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/question/controller/AnswerController.java
+++ b/src/main/java/com/moongeul/backend/api/question/controller/AnswerController.java
@@ -3,6 +3,7 @@ package com.moongeul.backend.api.question.controller;
 import com.moongeul.backend.api.question.dto.AnswerCreateRequestDTO;
 import com.moongeul.backend.api.question.dto.AnswerIdResponseDTO;
 import com.moongeul.backend.api.question.dto.AnswerListResponseDTO;
+import com.moongeul.backend.api.question.dto.AnswerModifyRequestDTO;
 import com.moongeul.backend.api.question.service.AnswerService;
 import com.moongeul.backend.common.response.ApiResponse;
 import com.moongeul.backend.common.response.SuccessStatus;
@@ -44,7 +45,7 @@ public class AnswerController {
 
     @Operation(
             summary = "답변 리스트 조회 API",
-            description = "질문에 달린 답변 리스트를 페이징하여 조회하는 API 입니다."
+            description = "특정 질문에 달린 답변 리스트를 페이징하여 조회하는 API 입니다. 답변 작성자의 프로필 이미지, 닉네임, 독서 취향 유형을 포함합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "답변 리스트 조회 성공"),
@@ -59,5 +60,43 @@ public class AnswerController {
 
         AnswerListResponseDTO answerListResponseDTO = answerService.getAnswerList(questionId, page, size, userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.GET_ANSWER_LIST_SUCCESS, answerListResponseDTO);
+    }
+
+    @Operation(
+            summary = "답변 수정 API",
+            description = "자신이 작성한 답변을 수정하는 API 입니다. 다른 사용자의 답변은 수정할 수 없습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "답변 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "답변 내용은 필수입니다"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "답변 수정 권한이 없습니다"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 답변을 찾을 수 없습니다")
+    })
+    @PutMapping("/{answerId}")
+    public ResponseEntity<ApiResponse<AnswerIdResponseDTO>> modifyAnswer(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long answerId,
+            @Valid @RequestBody AnswerModifyRequestDTO answerModifyRequestDTO) {
+
+        AnswerIdResponseDTO answerIdResponseDTO = answerService.modifyAnswer(answerId, answerModifyRequestDTO, userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.MODIFY_ANSWER_SUCCESS, answerIdResponseDTO);
+    }
+
+    @Operation(
+            summary = "답변 삭제 API",
+            description = "자신이 작성한 답변을 삭제하는 API 입니다. 다른 사용자의 답변은 삭제할 수 없습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "답변 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "답변 삭제 권한이 없습니다"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 답변을 찾을 수 없습니다")
+    })
+    @DeleteMapping("/{answerId}")
+    public ResponseEntity<ApiResponse<Void>> deleteAnswer(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long answerId) {
+
+        answerService.deleteAnswer(answerId, userDetails.getUsername());
+        return ApiResponse.success_only(SuccessStatus.DELETE_ANSWER_SUCCESS);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/question/controller/AnswerController.java
+++ b/src/main/java/com/moongeul/backend/api/question/controller/AnswerController.java
@@ -2,6 +2,7 @@ package com.moongeul.backend.api.question.controller;
 
 import com.moongeul.backend.api.question.dto.AnswerCreateRequestDTO;
 import com.moongeul.backend.api.question.dto.AnswerIdResponseDTO;
+import com.moongeul.backend.api.question.dto.AnswerListResponseDTO;
 import com.moongeul.backend.api.question.service.AnswerService;
 import com.moongeul.backend.common.response.ApiResponse;
 import com.moongeul.backend.common.response.SuccessStatus;
@@ -13,10 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Answer", description = "Answer(답변) 관련 API 입니다.")
 @RestController
@@ -42,5 +40,24 @@ public class AnswerController {
 
         AnswerIdResponseDTO answerIdResponseDTO = answerService.createAnswer(answerCreateRequestDTO, userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.CREATE_ANSWER_SUCCESS, answerIdResponseDTO);
+    }
+
+    @Operation(
+            summary = "답변 리스트 조회 API",
+            description = "질문에 달린 답변 리스트를 페이징하여 조회하는 API 입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "답변 리스트 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 질문을 찾을 수 없습니다")
+    })
+    @GetMapping("/list/{questionId}")
+    public ResponseEntity<ApiResponse<AnswerListResponseDTO>> getAnswerList(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long questionId,
+            @RequestParam(defaultValue = "1") Integer page,
+            @RequestParam(defaultValue = "10") Integer size) {
+
+        AnswerListResponseDTO answerListResponseDTO = answerService.getAnswerList(questionId, page, size, userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.GET_ANSWER_LIST_SUCCESS, answerListResponseDTO);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/question/controller/QuestionController.java
+++ b/src/main/java/com/moongeul/backend/api/question/controller/QuestionController.java
@@ -2,6 +2,7 @@ package com.moongeul.backend.api.question.controller;
 
 import com.moongeul.backend.api.question.dto.QuestionCreateRequestDTO;
 import com.moongeul.backend.api.question.dto.QuestionIdResponseDTO;
+import com.moongeul.backend.api.question.dto.QuestionListResponseDTO;
 import com.moongeul.backend.api.question.service.QuestionService;
 import com.moongeul.backend.common.response.ApiResponse;
 import com.moongeul.backend.common.response.SuccessStatus;
@@ -13,10 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Question", description = "Question(질문) 관련 API 입니다.")
 @RestController
@@ -41,5 +39,21 @@ public class QuestionController {
 
         QuestionIdResponseDTO response = questionService.createQuestion(questionCreateRequestDTO, userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.CREATE_QUESTION_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "질문 리스트 조회 API",
+            description = "질문 리스트를 페이징하여 조회하는 API 입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "질문 리스트 조회 성공")
+    })
+    @GetMapping("/list")
+    public ResponseEntity<ApiResponse<QuestionListResponseDTO>> getQuestionList(
+            @RequestParam(defaultValue = "1") Integer page,
+            @RequestParam(defaultValue = "10") Integer size) {
+
+        QuestionListResponseDTO questionListResponseDTO = questionService.getQuestionList(page, size);
+        return ApiResponse.success(SuccessStatus.GET_QUESTION_LIST_SUCCESS, questionListResponseDTO);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/question/controller/QuestionController.java
+++ b/src/main/java/com/moongeul/backend/api/question/controller/QuestionController.java
@@ -50,10 +50,11 @@ public class QuestionController {
     })
     @GetMapping("/list")
     public ResponseEntity<ApiResponse<QuestionListResponseDTO>> getQuestionList(
+            @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "10") Integer size) {
 
-        QuestionListResponseDTO questionListResponseDTO = questionService.getQuestionList(page, size);
+        QuestionListResponseDTO questionListResponseDTO = questionService.getQuestionList(page, size, userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.GET_QUESTION_LIST_SUCCESS, questionListResponseDTO);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/question/controller/QuestionController.java
+++ b/src/main/java/com/moongeul/backend/api/question/controller/QuestionController.java
@@ -96,4 +96,22 @@ public class QuestionController {
         QuestionIdResponseDTO questionIdResponseDTO = questionService.modifyQuestion(questionId, questionModifyRequestDTO, userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.MODIFY_QUESTION_SUCCESS, questionIdResponseDTO);
     }
+
+    @Operation(
+            summary = "질문 삭제 API",
+            description = "자신이 작성한 질문을 삭제하는 API 입니다. 질문과 연관된 모든 답변도 함께 삭제됩니다. (하드삭제 - 추후 소프트삭제 고려해야함)"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "질문 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "질문 삭제 권한이 없습니다"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 질문을 찾을 수 없습니다")
+    })
+    @DeleteMapping("/{questionId}")
+    public ResponseEntity<ApiResponse<Void>> deleteQuestion(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long questionId) {
+
+        questionService.deleteQuestion(questionId, userDetails.getUsername());
+        return ApiResponse.success_only(SuccessStatus.DELETE_QUESTION_SUCCESS);
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/question/controller/QuestionController.java
+++ b/src/main/java/com/moongeul/backend/api/question/controller/QuestionController.java
@@ -4,6 +4,7 @@ import com.moongeul.backend.api.question.dto.QuestionCreateRequestDTO;
 import com.moongeul.backend.api.question.dto.QuestionDTO;
 import com.moongeul.backend.api.question.dto.QuestionIdResponseDTO;
 import com.moongeul.backend.api.question.dto.QuestionListResponseDTO;
+import com.moongeul.backend.api.question.dto.QuestionModifyRequestDTO;
 import com.moongeul.backend.api.question.service.QuestionService;
 import com.moongeul.backend.common.response.ApiResponse;
 import com.moongeul.backend.common.response.SuccessStatus;
@@ -74,5 +75,25 @@ public class QuestionController {
 
         QuestionDTO questionDTO = questionService.getQuestionDetail(questionId, userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.GET_QUESTION_DETAIL_SUCCESS, questionDTO);
+    }
+
+    @Operation(
+            summary = "질문 수정 API",
+            description = "자신이 작성한 질문을 수정하는 API 입니다. 질문 내용과 책(ISBN)을 변경할 수 있습니다. 다른 사용자의 질문은 수정할 수 없습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "질문 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "질문 내용은 필수입니다 / ISBN은 필수입니다"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "질문 수정 권한이 없습니다"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 질문을 찾을 수 없습니다 / 해당 도서를 찾을 수 없습니다")
+    })
+    @PutMapping("/{questionId}")
+    public ResponseEntity<ApiResponse<QuestionIdResponseDTO>> modifyQuestion(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long questionId,
+            @Valid @RequestBody QuestionModifyRequestDTO questionModifyRequestDTO) {
+
+        QuestionIdResponseDTO questionIdResponseDTO = questionService.modifyQuestion(questionId, questionModifyRequestDTO, userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.MODIFY_QUESTION_SUCCESS, questionIdResponseDTO);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/question/controller/QuestionController.java
+++ b/src/main/java/com/moongeul/backend/api/question/controller/QuestionController.java
@@ -1,6 +1,7 @@
 package com.moongeul.backend.api.question.controller;
 
 import com.moongeul.backend.api.question.dto.QuestionCreateRequestDTO;
+import com.moongeul.backend.api.question.dto.QuestionDTO;
 import com.moongeul.backend.api.question.dto.QuestionIdResponseDTO;
 import com.moongeul.backend.api.question.dto.QuestionListResponseDTO;
 import com.moongeul.backend.api.question.service.QuestionService;
@@ -56,5 +57,22 @@ public class QuestionController {
 
         QuestionListResponseDTO questionListResponseDTO = questionService.getQuestionList(page, size, userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.GET_QUESTION_LIST_SUCCESS, questionListResponseDTO);
+    }
+
+    @Operation(
+            summary = "질문 상세 조회 API",
+            description = "특정 질문의 상세 정보를 조회하는 API 입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "질문 상세 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 질문을 찾을 수 없습니다.")
+    })
+    @GetMapping("/{questionId}")
+    public ResponseEntity<ApiResponse<QuestionDTO>> getQuestionDetail(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long questionId) {
+
+        QuestionDTO questionDTO = questionService.getQuestionDetail(questionId, userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.GET_QUESTION_DETAIL_SUCCESS, questionDTO);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/question/dto/AnswerCreateRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/question/dto/AnswerCreateRequestDTO.java
@@ -1,0 +1,32 @@
+package com.moongeul.backend.api.question.dto;
+
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.question.entity.Answer;
+import com.moongeul.backend.api.question.entity.Question;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerCreateRequestDTO {
+
+    @NotNull(message = "질문 ID는 필수입니다")
+    private Long questionId; // 질문 ID
+
+    @NotBlank(message = "답변 내용은 필수입니다")
+    private String content; // 답변 내용
+
+    public Answer toEntity(Member member, Question question) {
+        return Answer.builder()
+                .content(this.content)
+                .question(question)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/question/dto/AnswerDTO.java
+++ b/src/main/java/com/moongeul/backend/api/question/dto/AnswerDTO.java
@@ -1,0 +1,33 @@
+package com.moongeul.backend.api.question.dto;
+
+import com.moongeul.backend.api.member.entity.ReadingTasteType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerDTO {
+
+    private Long answerId; // 댓글 ID
+    private String content; // 댓글 내용
+    private LocalDateTime createdAt; // 생성일자
+    private Boolean myAnswer; // 내가 단 댓글인지 여부
+
+    private MemberInfo memberInfo; // 댓글 작성자 정보
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberInfo {
+        private String profileImage; // 프로필 이미지
+        private String nickname; // 닉네임
+        private ReadingTasteType readingTasteType; // 독서 취향 유형
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/question/dto/AnswerIdResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/question/dto/AnswerIdResponseDTO.java
@@ -1,0 +1,14 @@
+package com.moongeul.backend.api.question.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerIdResponseDTO {
+    private Long answerId; // 생성된 답변 ID
+}

--- a/src/main/java/com/moongeul/backend/api/question/dto/AnswerListResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/question/dto/AnswerListResponseDTO.java
@@ -1,0 +1,22 @@
+package com.moongeul.backend.api.question.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerListResponseDTO {
+
+    private Long total; // 전체 검색 결과 수
+    private Integer page; // 현재 페이지
+    private Integer size; // 페이지당 개수
+    private Integer totalPages; // 전체 페이지 수
+    private Boolean isLast; // 마지막 페이지 여부
+    private List<AnswerDTO> data; // 답변 리스트
+}

--- a/src/main/java/com/moongeul/backend/api/question/dto/AnswerModifyRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/question/dto/AnswerModifyRequestDTO.java
@@ -1,0 +1,17 @@
+package com.moongeul.backend.api.question.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerModifyRequestDTO {
+
+    @NotBlank(message = "답변 내용은 필수입니다")
+    private String content; // 수정할 답변 내용
+}

--- a/src/main/java/com/moongeul/backend/api/question/dto/QuestionDTO.java
+++ b/src/main/java/com/moongeul/backend/api/question/dto/QuestionDTO.java
@@ -18,7 +18,7 @@ public class QuestionDTO {
     private String content; // 질문 내용
     private Integer commentCnt; // 댓글 수
     private LocalDateTime createdAt; // 작성 시간
-
+    private Boolean myArticle; // 내가 작성한 질문 인지 여부
     private BookInfo bookInfo; // 책 정보
     private Integer participantCount; // 총 참여 인원 수 (중복 제외, 질문 작성자 포함)
     private List<String> participantProfileImages; // 참여자 프로필 이미지 (최대 3명)

--- a/src/main/java/com/moongeul/backend/api/question/dto/QuestionDTO.java
+++ b/src/main/java/com/moongeul/backend/api/question/dto/QuestionDTO.java
@@ -1,0 +1,39 @@
+package com.moongeul.backend.api.question.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionDTO {
+
+    private Long questionId; // 질문 ID
+    private String content; // 질문 내용
+    private Integer commentCnt; // 댓글 수
+    private LocalDateTime createdAt; // 작성 시간
+
+    private BookInfo bookInfo; // 책 정보
+    private Integer participantCount; // 총 참여 인원 수 (중복 제외, 질문 작성자 포함)
+    private List<String> participantProfileImages; // 참여자 프로필 이미지 (최대 3명)
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BookInfo {
+        private String isbn; // ISBN
+        private String bookImage; // 표지 이미지
+        private String title; // 책 제목
+        private String author; // 저자
+        private String publisher; // 출판사
+        private String pubdate; // 출판연도
+        private Double ratingAverage; // 별점 평균
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/question/dto/QuestionListResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/question/dto/QuestionListResponseDTO.java
@@ -1,0 +1,22 @@
+package com.moongeul.backend.api.question.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionListResponseDTO {
+
+    private Long total; // 전체 검색 결과 수
+    private Integer page; // 현재 페이지
+    private Integer size; // 페이지당 개수
+    private Integer totalPages; // 전체 페이지 수
+    private Boolean isLast; // 마지막 페이지 여부
+    private List<QuestionDTO> data; // 질문 리스트
+}

--- a/src/main/java/com/moongeul/backend/api/question/dto/QuestionModifyRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/question/dto/QuestionModifyRequestDTO.java
@@ -1,0 +1,20 @@
+package com.moongeul.backend.api.question.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionModifyRequestDTO {
+
+    @NotBlank(message = "ISBN은 필수입니다")
+    private String isbn; // 수정할 책 ISBN
+
+    @NotBlank(message = "질문 내용은 필수입니다")
+    private String content; // 수정할 질문 내용
+}

--- a/src/main/java/com/moongeul/backend/api/question/entity/Answer.java
+++ b/src/main/java/com/moongeul/backend/api/question/entity/Answer.java
@@ -1,0 +1,33 @@
+package com.moongeul.backend.api.question.entity;
+
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "ANSWER")
+public class Answer extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 답변 id
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content; // 답변 내용
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private Question question; // 질문
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member; // 답변 작성자
+}

--- a/src/main/java/com/moongeul/backend/api/question/entity/Answer.java
+++ b/src/main/java/com/moongeul/backend/api/question/entity/Answer.java
@@ -30,4 +30,9 @@ public class Answer extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member; // 답변 작성자
+
+    // 답변 내용 수정
+    public void modify(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/question/entity/Question.java
+++ b/src/main/java/com/moongeul/backend/api/question/entity/Question.java
@@ -31,4 +31,16 @@ public class Question extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_isbn", nullable = false)
     private Book book;
+
+    // 댓글 수 증가
+    public void increaseCommentCnt() {
+        this.commentCnt++;
+    }
+
+    // 댓글 수 감소
+    public void decreaseCommentCnt() {
+        if (this.commentCnt > 0) {
+            this.commentCnt--;
+        }
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/question/entity/Question.java
+++ b/src/main/java/com/moongeul/backend/api/question/entity/Question.java
@@ -43,4 +43,10 @@ public class Question extends BaseTimeEntity {
             this.commentCnt--;
         }
     }
+
+    // 질문 수정 (내용과 책)
+    public void modify(String content, Book book) {
+        this.content = content;
+        this.book = book;
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/question/repository/AnswerRepository.java
+++ b/src/main/java/com/moongeul/backend/api/question/repository/AnswerRepository.java
@@ -1,9 +1,18 @@
 package com.moongeul.backend.api.question.repository;
 
+import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.question.entity.Answer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+    // 특정 질문의 답변 작성자 목록 조회 (중복 제거)
+    @Query("SELECT DISTINCT a.member FROM Answer a WHERE a.question.id = :questionId")
+    List<Member> findDistinctMembersByQuestionId(@Param("questionId") Long questionId);
 }

--- a/src/main/java/com/moongeul/backend/api/question/repository/AnswerRepository.java
+++ b/src/main/java/com/moongeul/backend/api/question/repository/AnswerRepository.java
@@ -2,6 +2,8 @@ package com.moongeul.backend.api.question.repository;
 
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.question.entity.Answer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +20,8 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     // 특정 질문의 모든 답변 삭제
     void deleteByQuestionId(Long questionId);
+
+    // 특정 질문의 답변 리스트 조회 (페이징, 최신순)
+    @Query("SELECT a FROM Answer a WHERE a.question.id = :questionId ORDER BY a.createdAt DESC")
+    Page<Answer> findByQuestionId(@Param("questionId") Long questionId, Pageable pageable);
 }

--- a/src/main/java/com/moongeul/backend/api/question/repository/AnswerRepository.java
+++ b/src/main/java/com/moongeul/backend/api/question/repository/AnswerRepository.java
@@ -1,0 +1,9 @@
+package com.moongeul.backend.api.question.repository;
+
+import com.moongeul.backend.api.question.entity.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+}

--- a/src/main/java/com/moongeul/backend/api/question/repository/AnswerRepository.java
+++ b/src/main/java/com/moongeul/backend/api/question/repository/AnswerRepository.java
@@ -15,4 +15,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     // 특정 질문의 답변 작성자 목록 조회 (중복 제거)
     @Query("SELECT DISTINCT a.member FROM Answer a WHERE a.question.id = :questionId")
     List<Member> findDistinctMembersByQuestionId(@Param("questionId") Long questionId);
+
+    // 특정 질문의 모든 답변 삭제
+    void deleteByQuestionId(Long questionId);
 }

--- a/src/main/java/com/moongeul/backend/api/question/repository/QuestionRepository.java
+++ b/src/main/java/com/moongeul/backend/api/question/repository/QuestionRepository.java
@@ -1,7 +1,14 @@
 package com.moongeul.backend.api.question.repository;
 
 import com.moongeul.backend.api.question.entity.Question;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface QuestionRepository extends JpaRepository<Question, Long>  {
+
+    // 질문 전체 조회 (최신순)
+    @Query("SELECT q FROM Question q ORDER BY q.createdAt DESC")
+    Page<Question> findAllQuestions(Pageable pageable);
 }

--- a/src/main/java/com/moongeul/backend/api/question/service/AnswerService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/AnswerService.java
@@ -40,8 +40,11 @@ public class AnswerService {
         Answer newAnswer = answerCreateRequestDTO.toEntity(member, question);
         Answer savedAnswer = answerRepository.save(newAnswer);
 
-        log.info("답변 생성 완료 - 답변 ID: {}, 질문 ID: {}, 작성자: {}",
-                savedAnswer.getId(), question.getId(), member.getEmail());
+        // 질문의 댓글 수 증가
+        question.increaseCommentCnt();
+
+        log.info("답변 생성 완료 - 답변 ID: {}, 질문 ID: {}, 작성자: {}, 현재 댓글 수: {}",
+                savedAnswer.getId(), question.getId(), member.getEmail(), question.getCommentCnt());
 
         return AnswerIdResponseDTO.builder()
                 .answerId(savedAnswer.getId())

--- a/src/main/java/com/moongeul/backend/api/question/service/AnswerService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/AnswerService.java
@@ -1,0 +1,50 @@
+package com.moongeul.backend.api.question.service;
+
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.api.question.dto.AnswerCreateRequestDTO;
+import com.moongeul.backend.api.question.dto.AnswerIdResponseDTO;
+import com.moongeul.backend.api.question.entity.Answer;
+import com.moongeul.backend.api.question.entity.Question;
+import com.moongeul.backend.api.question.repository.AnswerRepository;
+import com.moongeul.backend.api.question.repository.QuestionRepository;
+import com.moongeul.backend.common.exception.NotFoundException;
+import com.moongeul.backend.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnswerService {
+
+    private final MemberRepository memberRepository;
+    private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
+
+    // 답변 생성
+    @Transactional
+    public AnswerIdResponseDTO createAnswer(AnswerCreateRequestDTO answerCreateRequestDTO, String email) {
+
+        // 사용자 조회
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        // 질문 조회
+        Question question = questionRepository.findById(answerCreateRequestDTO.getQuestionId())
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.QUESTION_NOTFOUND_EXCEPTION.getMessage()));
+
+        // 답변 생성
+        Answer newAnswer = answerCreateRequestDTO.toEntity(member, question);
+        Answer savedAnswer = answerRepository.save(newAnswer);
+
+        log.info("답변 생성 완료 - 답변 ID: {}, 질문 ID: {}, 작성자: {}",
+                savedAnswer.getId(), question.getId(), member.getEmail());
+
+        return AnswerIdResponseDTO.builder()
+                .answerId(savedAnswer.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/question/service/AnswerService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/AnswerService.java
@@ -6,11 +6,13 @@ import com.moongeul.backend.api.question.dto.AnswerCreateRequestDTO;
 import com.moongeul.backend.api.question.dto.AnswerDTO;
 import com.moongeul.backend.api.question.dto.AnswerIdResponseDTO;
 import com.moongeul.backend.api.question.dto.AnswerListResponseDTO;
+import com.moongeul.backend.api.question.dto.AnswerModifyRequestDTO;
 import com.moongeul.backend.api.question.entity.Answer;
 import com.moongeul.backend.api.question.entity.Question;
 import com.moongeul.backend.api.question.repository.AnswerRepository;
 import com.moongeul.backend.api.question.repository.QuestionRepository;
 import com.moongeul.backend.common.exception.NotFoundException;
+import com.moongeul.backend.common.exception.UnauthorizedException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -81,6 +83,53 @@ public class AnswerService {
                 .isLast(answerPage.isLast())
                 .data(answerDTOList)
                 .build();
+    }
+
+    // 답변 수정
+    @Transactional
+    public AnswerIdResponseDTO modifyAnswer(Long answerId, AnswerModifyRequestDTO requestDTO, String email) {
+
+        // 답변 조회
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.ANSWER_NOTFOUND_EXCEPTION.getMessage()));
+
+        // 작성자 확인 (자신이 작성한 답변만 수정 가능)
+        if (!answer.getMember().getEmail().equals(email)) {
+            throw new UnauthorizedException(ErrorStatus.ANSWER_UNAUTHORIZED.getMessage());
+        }
+
+        // 답변 내용 수정
+        answer.modify(requestDTO.getContent());
+
+        log.info("답변 수정 완료 - 답변 ID: {}, 작성자: {}", answerId, email);
+
+        return AnswerIdResponseDTO.builder()
+                .answerId(answer.getId())
+                .build();
+    }
+
+    // 답변 삭제
+    @Transactional
+    public void deleteAnswer(Long answerId, String email) {
+
+        // 답변 조회
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.ANSWER_NOTFOUND_EXCEPTION.getMessage()));
+
+        // 작성자 확인 (자신이 작성한 답변만 삭제 가능)
+        if (!answer.getMember().getEmail().equals(email)) {
+            throw new UnauthorizedException(ErrorStatus.ANSWER_UNAUTHORIZED.getMessage());
+        }
+
+        // 질문의 댓글 수 감소
+        Question question = answer.getQuestion();
+        question.decreaseCommentCnt();
+
+        // 답변 삭제 (하드 삭제)
+        answerRepository.delete(answer);
+
+        log.info("답변 삭제 완료 - 답변 ID: {}, 작성자: {}, 질문 ID: {}, 현재 댓글 수: {}",
+                answerId, email, question.getId(), question.getCommentCnt());
     }
 
     // Answer 엔티티를 AnswerDTO로 변환

--- a/src/main/java/com/moongeul/backend/api/question/service/AnswerService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/AnswerService.java
@@ -3,7 +3,9 @@ package com.moongeul.backend.api.question.service;
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.api.question.dto.AnswerCreateRequestDTO;
+import com.moongeul.backend.api.question.dto.AnswerDTO;
 import com.moongeul.backend.api.question.dto.AnswerIdResponseDTO;
+import com.moongeul.backend.api.question.dto.AnswerListResponseDTO;
 import com.moongeul.backend.api.question.entity.Answer;
 import com.moongeul.backend.api.question.entity.Question;
 import com.moongeul.backend.api.question.repository.AnswerRepository;
@@ -12,8 +14,14 @@ import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -48,6 +56,51 @@ public class AnswerService {
 
         return AnswerIdResponseDTO.builder()
                 .answerId(savedAnswer.getId())
+                .build();
+    }
+
+    // 답변 리스트 조회
+    public AnswerListResponseDTO getAnswerList(Long questionId, Integer page, Integer size, String email) {
+
+        // 질문 존재 여부 확인
+        questionRepository.findById(questionId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.QUESTION_NOTFOUND_EXCEPTION.getMessage()));
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Answer> answerPage = answerRepository.findByQuestionId(questionId, pageable);
+
+        List<AnswerDTO> answerDTOList = answerPage.getContent().stream()
+                .map(answer -> convertToAnswerDTO(answer, email))
+                .collect(Collectors.toList());
+
+        return AnswerListResponseDTO.builder()
+                .total(answerPage.getTotalElements())
+                .page(page)
+                .size(size)
+                .totalPages(answerPage.getTotalPages())
+                .isLast(answerPage.isLast())
+                .data(answerDTOList)
+                .build();
+    }
+
+    // Answer 엔티티를 AnswerDTO로 변환
+    private AnswerDTO convertToAnswerDTO(Answer answer, String email) {
+
+        Member member = answer.getMember();
+
+        // 내가 작성한 답변인지 확인
+        boolean isMyAnswer = member.getEmail().equals(email);
+
+        return AnswerDTO.builder()
+                .answerId(answer.getId())
+                .content(answer.getContent())
+                .createdAt(answer.getCreatedAt())
+                .myAnswer(isMyAnswer)
+                .memberInfo(AnswerDTO.MemberInfo.builder()
+                        .profileImage(member.getProfileImage())
+                        .nickname(member.getNickname())
+                        .readingTasteType(member.getReadingTasteType())
+                        .build())
                 .build();
     }
 }

--- a/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
@@ -113,6 +113,27 @@ public class QuestionService {
                 .build();
     }
 
+    // 질문 삭제
+    @Transactional
+    public void deleteQuestion(Long questionId, String email) {
+
+        // 질문 조회
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.QUESTION_NOTFOUND_EXCEPTION.getMessage()));
+
+        // 작성자 확인 (자신이 작성한 질문만 삭제 가능)
+        if (!question.getMember().getEmail().equals(email)) {
+            throw new UnauthorizedException(ErrorStatus.QUESTION_UNAUTHORIZED.getMessage());
+        }
+
+        // 연관된 모든 답변 삭제 (하드 삭제)
+        answerRepository.deleteByQuestionId(questionId);
+
+        questionRepository.delete(question);
+
+        log.info("질문 삭제 완료 - 질문 ID: {}, 작성자: {}", questionId, email);
+    }
+
     // Question 엔티티를 QuestionDTO로 변환
     private QuestionDTO convertToQuestionDTO(Question question, String email) {
 

--- a/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -36,6 +37,7 @@ public class QuestionService {
     private final AnswerRepository answerRepository;
 
     /* 질문 생성 */
+    @Transactional
     public QuestionIdResponseDTO createQuestion(QuestionCreateRequestDTO questionCreateRequestDTO, String email){
 
         Member member = memberRepository.findByEmail(email)
@@ -70,6 +72,16 @@ public class QuestionService {
                 .isLast(questionPage.isLast())
                 .data(questionDTOList)
                 .build();
+    }
+
+    // 질문 상세 조회
+    public QuestionDTO getQuestionDetail(Long questionId, String email) {
+
+        // 질문 조회
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.QUESTION_NOTFOUND_EXCEPTION.getMessage()));
+
+        return convertToQuestionDTO(question, email);
     }
 
     // Question 엔티티를 QuestionDTO로 변환

--- a/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
@@ -5,14 +5,25 @@ import com.moongeul.backend.api.book.repository.BookRepository;
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.api.question.dto.QuestionCreateRequestDTO;
+import com.moongeul.backend.api.question.dto.QuestionDTO;
 import com.moongeul.backend.api.question.dto.QuestionIdResponseDTO;
+import com.moongeul.backend.api.question.dto.QuestionListResponseDTO;
 import com.moongeul.backend.api.question.entity.Question;
+import com.moongeul.backend.api.question.repository.AnswerRepository;
 import com.moongeul.backend.api.question.repository.QuestionRepository;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -22,6 +33,7 @@ public class QuestionService {
     private final MemberRepository memberRepository;
     private final BookRepository bookRepository;
     private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
 
     /* 질문 생성 */
     public QuestionIdResponseDTO createQuestion(QuestionCreateRequestDTO questionCreateRequestDTO, String email){
@@ -37,6 +49,64 @@ public class QuestionService {
 
         return QuestionIdResponseDTO.builder()
                 .questionId(savedQuestion.getId())
+                .build();
+    }
+
+    // 질문 리스트 조회
+    public QuestionListResponseDTO getQuestionList(Integer page, Integer size) {
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Question> questionPage = questionRepository.findAllQuestions(pageable);
+
+        List<QuestionDTO> questionDTOList = questionPage.getContent().stream()
+                .map(this::convertToQuestionDTO)
+                .collect(Collectors.toList());
+
+        return QuestionListResponseDTO.builder()
+                .total(questionPage.getTotalElements())
+                .page(page)
+                .size(size)
+                .totalPages(questionPage.getTotalPages())
+                .isLast(questionPage.isLast())
+                .data(questionDTOList)
+                .build();
+    }
+
+    // Question 엔티티를 QuestionDTO로 변환
+    private QuestionDTO convertToQuestionDTO(Question question) {
+
+        Book book = question.getBook();
+
+        // 답변 작성자 목록 조회 (중복 제거)
+        List<Member> answerMembers = answerRepository.findDistinctMembersByQuestionId(question.getId());
+
+        // 참여자 목록 = 질문 작성자 + 답변 작성자 (중복 제거)
+        Set<Member> participantSet = new LinkedHashSet<>();
+        participantSet.add(question.getMember()); // 질문 작성자 추가
+        participantSet.addAll(answerMembers); // 답변 작성자들 추가
+
+        // 참여자 프로필 이미지 (최대 3명)
+        List<String> participantProfileImages = participantSet.stream()
+                .limit(3)
+                .map(Member::getProfileImage)
+                .collect(Collectors.toList());
+
+        return QuestionDTO.builder()
+                .questionId(question.getId())
+                .content(question.getContent())
+                .commentCnt(question.getCommentCnt())
+                .createdAt(question.getCreatedAt())
+                .bookInfo(QuestionDTO.BookInfo.builder()
+                        .isbn(book.getIsbn())
+                        .bookImage(book.getBookImage())
+                        .title(book.getTitle())
+                        .author(book.getAuthor())
+                        .publisher(book.getPublisher())
+                        .pubdate(book.getPubdate())
+                        .ratingAverage(book.getRatingAverage())
+                        .build())
+                .participantCount(participantSet.size())
+                .participantProfileImages(participantProfileImages)
                 .build();
     }
 }

--- a/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
@@ -8,10 +8,12 @@ import com.moongeul.backend.api.question.dto.QuestionCreateRequestDTO;
 import com.moongeul.backend.api.question.dto.QuestionDTO;
 import com.moongeul.backend.api.question.dto.QuestionIdResponseDTO;
 import com.moongeul.backend.api.question.dto.QuestionListResponseDTO;
+import com.moongeul.backend.api.question.dto.QuestionModifyRequestDTO;
 import com.moongeul.backend.api.question.entity.Question;
 import com.moongeul.backend.api.question.repository.AnswerRepository;
 import com.moongeul.backend.api.question.repository.QuestionRepository;
 import com.moongeul.backend.common.exception.NotFoundException;
+import com.moongeul.backend.common.exception.UnauthorizedException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -82,6 +84,33 @@ public class QuestionService {
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.QUESTION_NOTFOUND_EXCEPTION.getMessage()));
 
         return convertToQuestionDTO(question, email);
+    }
+
+    // 질문 수정
+    @Transactional
+    public QuestionIdResponseDTO modifyQuestion(Long questionId, QuestionModifyRequestDTO requestDTO, String email) {
+
+        // 질문 조회
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.QUESTION_NOTFOUND_EXCEPTION.getMessage()));
+
+        // 작성자 확인 (자신이 작성한 질문만 수정 가능)
+        if (!question.getMember().getEmail().equals(email)) {
+            throw new UnauthorizedException(ErrorStatus.QUESTION_UNAUTHORIZED.getMessage());
+        }
+
+        // 책 조회
+        Book book = bookRepository.findByIsbn(requestDTO.getIsbn())
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.BOOK_NOTFOUND_EXCEPTION.getMessage()));
+
+        // 질문 수정 (내용과 책)
+        question.modify(requestDTO.getContent(), book);
+
+        log.info("질문 수정 완료 - 질문 ID: {}, 작성자: {}, 새 ISBN: {}", questionId, email, requestDTO.getIsbn());
+
+        return QuestionIdResponseDTO.builder()
+                .questionId(question.getId())
+                .build();
     }
 
     // Question 엔티티를 QuestionDTO로 변환

--- a/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
@@ -53,13 +53,13 @@ public class QuestionService {
     }
 
     // 질문 리스트 조회
-    public QuestionListResponseDTO getQuestionList(Integer page, Integer size) {
+    public QuestionListResponseDTO getQuestionList(Integer page, Integer size, String email) {
 
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<Question> questionPage = questionRepository.findAllQuestions(pageable);
 
         List<QuestionDTO> questionDTOList = questionPage.getContent().stream()
-                .map(this::convertToQuestionDTO)
+                .map(question -> convertToQuestionDTO(question, email))
                 .collect(Collectors.toList());
 
         return QuestionListResponseDTO.builder()
@@ -73,7 +73,7 @@ public class QuestionService {
     }
 
     // Question 엔티티를 QuestionDTO로 변환
-    private QuestionDTO convertToQuestionDTO(Question question) {
+    private QuestionDTO convertToQuestionDTO(Question question, String email) {
 
         Book book = question.getBook();
 
@@ -91,11 +91,15 @@ public class QuestionService {
                 .map(Member::getProfileImage)
                 .collect(Collectors.toList());
 
+        // 내가 작성한 질문인지 확인
+        boolean isMyArticle = question.getMember().getEmail().equals(email);
+
         return QuestionDTO.builder()
                 .questionId(question.getId())
                 .content(question.getContent())
                 .commentCnt(question.getCommentCnt())
                 .createdAt(question.getCreatedAt())
+                .myArticle(isMyArticle)
                 .bookInfo(QuestionDTO.BookInfo.builder()
                         .isbn(book.getIsbn())
                         .bookImage(book.getBookImage())

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -44,6 +44,7 @@ public enum ErrorStatus {
     REVIEW_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 리뷰를 찾을 수 없습니다."),
     USER_READING_TASTE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "사용자의 독서 취향 정보를 찾을 수 없습니다."),
     WEEKLY_RECOMMENDATION_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "주간 추천 기록을 찾을 수 없습니다."),
+    QUESTION_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 질문을 찾을 수 없습니다."),
 
     /**
      * 400 BAD_REQUEST

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -33,6 +33,7 @@ public enum ErrorStatus {
     TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었거나 유효하지 않은 토큰입니다."),
     POST_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "회원의 게시글이 아닙니다."),
     CATEGORY_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "회원의 카테고리가 아닙니다."),
+    QUESTION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "질문 수정 권한이 없습니다."),
 
     /**
      * 404 NOT_FOUND

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus {
     POST_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "회원의 게시글이 아닙니다."),
     CATEGORY_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "회원의 카테고리가 아닙니다."),
     QUESTION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "질문 수정 권한이 없습니다."),
+    ANSWER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "답변 수정 권한이 없습니다."),
 
     /**
      * 404 NOT_FOUND
@@ -46,6 +47,7 @@ public enum ErrorStatus {
     USER_READING_TASTE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "사용자의 독서 취향 정보를 찾을 수 없습니다."),
     WEEKLY_RECOMMENDATION_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "주간 추천 기록을 찾을 수 없습니다."),
     QUESTION_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 질문을 찾을 수 없습니다."),
+    ANSWER_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 답변을 찾을 수 없습니다."),
 
     /**
      * 400 BAD_REQUEST

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -84,6 +84,8 @@ public enum SuccessStatus {
 	/* ANSWER */
 	CREATE_ANSWER_SUCCESS(HttpStatus.CREATED, "답변 생성 성공"),
 	GET_ANSWER_LIST_SUCCESS(HttpStatus.OK, "답변 리스트 조회 성공"),
+	MODIFY_ANSWER_SUCCESS(HttpStatus.OK, "답변 수정 성공"),
+	DELETE_ANSWER_SUCCESS(HttpStatus.OK, "답변 삭제 성공"),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -57,6 +57,7 @@ public enum SuccessStatus {
 
 	/* QUESTION */
 	GET_QUESTION_LIST_SUCCESS(HttpStatus.OK, "질문 리스트 조회 성공"),
+	GET_QUESTION_DETAIL_SUCCESS(HttpStatus.OK, "질문 상세 조회 성공"),
 
 
 	/**

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -59,6 +59,7 @@ public enum SuccessStatus {
 	GET_QUESTION_LIST_SUCCESS(HttpStatus.OK, "질문 리스트 조회 성공"),
 	GET_QUESTION_DETAIL_SUCCESS(HttpStatus.OK, "질문 상세 조회 성공"),
 	MODIFY_QUESTION_SUCCESS(HttpStatus.OK, "질문 수정 성공"),
+	DELETE_QUESTION_SUCCESS(HttpStatus.OK, "질문 삭제 성공"),
 
 
 	/**

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -58,6 +58,7 @@ public enum SuccessStatus {
 	/* QUESTION */
 	GET_QUESTION_LIST_SUCCESS(HttpStatus.OK, "질문 리스트 조회 성공"),
 	GET_QUESTION_DETAIL_SUCCESS(HttpStatus.OK, "질문 상세 조회 성공"),
+	MODIFY_QUESTION_SUCCESS(HttpStatus.OK, "질문 수정 성공"),
 
 
 	/**

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -55,6 +55,9 @@ public enum SuccessStatus {
 	/* ALARM */
 	REGISTER_DEVICE_TOKEN(HttpStatus.OK, "사용자 기기 토큰 등록 성공"),
 
+	/* QUESTION */
+	GET_QUESTION_LIST_SUCCESS(HttpStatus.OK, "질문 리스트 조회 성공"),
+
 
 	/**
 	 * 201

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -83,6 +83,7 @@ public enum SuccessStatus {
 
 	/* ANSWER */
 	CREATE_ANSWER_SUCCESS(HttpStatus.CREATED, "답변 생성 성공"),
+	GET_ANSWER_LIST_SUCCESS(HttpStatus.OK, "답변 리스트 조회 성공"),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -74,6 +74,9 @@ public enum SuccessStatus {
 
 	/* QUESTION */
 	CREATE_QUESTION_SUCCESS(HttpStatus.CREATED, "질문 생성 성공"),
+
+	/* ANSWER */
+	CREATE_ANSWER_SUCCESS(HttpStatus.CREATED, "답변 생성 성공"),
 	;
 
 	private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #41

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 등록된 질문에 대한 답변을 작성하는 기능을 구현하였습니다.
- 등록된 질문/답변을 조회하는 기능을 구현하였습니다. (리스트/상세조회)
- 등록된 질문/답변을 수정하는 기능을 구현하였습니다.
- 등록된 질문/답변을 삭제하는 기능을 구현하였습니다.

- 질문 게시글 등록할때 트랜잭션이 빠져있어서 해당 부분 등록해두었습니다.

P.S) 현재는 삭제를 하드삭제로 구현하긴했는데 추후 배포/운영 할때에는 운영 안정성을 위해서 소프트삭제로 변경하는것을 권장합니다. 또한 법적 문제를 고려해서 IP정보를 수집하는것도 고려하면 좋을거 같습니다~ 그리고 지금 수정한거에 대해서 따로 (수정됨) 같은 표시를 안하는것으로 알고있는데 이거 관련해서는 다음 회의때 논의해보면 좋을거같아요.

제가 커밋할때 답변 등록 기능 구현으로 써야하는데 질문 등록 기능 구현으로 해놨네요.. 이건 애교로 봐주세요...

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 질문 관련 API ]
<img width="1435" height="333" alt="image" src="https://github.com/user-attachments/assets/11209422-1369-4b25-9f1a-a1f29dffcf26" />

[ 답변 관련 API ]
<img width="1435" height="282" alt="image" src="https://github.com/user-attachments/assets/e92b822f-44c0-4fcf-9676-5ab8ebd19344" />
