### PR TITLE
[FIX] 책장 응답 필드 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/bookshelf/dto/DoneReadBookshelfResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/dto/DoneReadBookshelfResponseDTO.java
@@ -17,6 +17,6 @@ public class DoneReadBookshelfResponseDTO {
     private Integer size; // 페이지당 개수
     private Integer totalPages; // 전체 페이지 수
     private Boolean isLast; // 마지막 페이지 여부
-    private List<DoneReadBookshelfItemDTO> books; // 읽은 책 목록
+    private List<DoneReadBookshelfItemDTO> data; // 읽은 책 목록
 }
 

--- a/src/main/java/com/moongeul/backend/api/bookshelf/dto/WishReadBookshelfResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/dto/WishReadBookshelfResponseDTO.java
@@ -18,6 +18,6 @@ public class WishReadBookshelfResponseDTO {
     private Integer size; // 페이지당 개수
     private Integer totalPages; // 전체 페이지 수
     private Boolean isLast; // 마지막 페이지 여부
-    private List<BookDTO> books; // 읽고 싶은 책 목록
+    private List<BookDTO> data; // 읽고 싶은 책 목록
 }
 

--- a/src/main/java/com/moongeul/backend/api/bookshelf/service/DoneReadBookshelfService.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/service/DoneReadBookshelfService.java
@@ -54,7 +54,7 @@ public class DoneReadBookshelfService {
                 .size(size)
                 .totalPages(totalPages)
                 .isLast(isLast)
-                .books(books)
+                .data(books)
                 .build();
     }
 

--- a/src/main/java/com/moongeul/backend/api/bookshelf/service/WishReadBookshelfService.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/service/WishReadBookshelfService.java
@@ -99,7 +99,7 @@ public class WishReadBookshelfService {
                 .size(size)
                 .totalPages(totalPages)
                 .isLast(isLast)
-                .books(books)
+                .data(books)
                 .build();
     }
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #51

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 프론트엔드 요청으로 읽고 싶은 책장, 읽은 책장 응답 필드 books 를 data로 변경하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 읽고 싶은 책장 응답 필드 수정 ] 
<img width="1208" height="404" alt="image" src="https://github.com/user-attachments/assets/9ca83310-802c-48bd-97ae-f0dde07227e7" />

[ 읽은 책장 응답 필드 수정 ]
<img width="1208" height="390" alt="image" src="https://github.com/user-attachments/assets/739508a7-4776-4e63-8297-7409bc2108d5" />
