### PR TITLE
[FEAT] 마이페이지 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.moongeul.backend.api.member.dto.*;
 import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
 import com.moongeul.backend.api.member.service.FollowService;
 import com.moongeul.backend.api.member.service.MemberService;
+import com.moongeul.backend.api.post.dto.CategoryPostListResponseDTO;
 import com.moongeul.backend.common.response.ApiResponse;
 import com.moongeul.backend.common.response.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -107,6 +108,30 @@ public class MemberController {
             @RequestParam(required = false) Long userId){
         PostStatsResponseDTO response = memberService.getPostStats(userDetails.getUsername(), userId);
         return ApiResponse.success(SuccessStatus.GET_POST_STATS_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "카테고리별 기록 리스트 조회 API (마이페이지 기록장 상세)",
+            description = "특정 카테고리에 작성된 기록들을 조회합니다. 최신순, 오래된순, 평점 높은순, 평점 낮은순으로 정렬할 수 있습니다." +
+                    "<br><br>[enum] 정렬 옵션 (sortBy):" +
+                    "<br>- LATEST: 최신순 (기본값)" +
+                    "<br>- OLDEST: 오래된순" +
+                    "<br>- RATING_HIGH: 평점 높은순" +
+                    "<br>- RATING_LOW: 평점 낮은순"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카테고리별 기록 리스트 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 카테고리를 찾을 수 없습니다.")
+    })
+    @GetMapping("/post-stats/{categoryId}")
+    public ResponseEntity<ApiResponse<CategoryPostListResponseDTO>> getCategoryPostList(
+            @PathVariable Long categoryId,
+            @RequestParam(defaultValue = "LATEST") String sortBy,
+            @RequestParam(defaultValue = "1") Integer page,
+            @RequestParam(defaultValue = "10") Integer size) {
+
+        CategoryPostListResponseDTO categoryPostListResponseDTO = memberService.getCategoryPostList(categoryId, sortBy, page, size);
+        return ApiResponse.success(SuccessStatus.GET_CATEGORY_POST_LIST_SUCCESS, categoryPostListResponseDTO);
     }
 
     @Operation(

--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -93,6 +93,23 @@ public class MemberController {
     }
 
     @Operation(
+            summary = "기록 통계 조회 API (마이페이지 기록장)",
+            description = "사용자의 기록 작성 통계를 조회합니다. userId 쿼리 파라미터가 없으면 본인 정보를 조회하고, 있으면 해당 사용자의 정보를 조회합니다. " +
+                    "전체 작성 갯수와 카테고리별 기록 갯수, 카테고리 이름, 카테고리 ID를 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "기록 통계 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
+    })
+    @GetMapping("/post-stats")
+    public ResponseEntity<ApiResponse<PostStatsResponseDTO>> getPostStats(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) Long userId){
+        PostStatsResponseDTO response = memberService.getPostStats(userDetails.getUsername(), userId);
+        return ApiResponse.success(SuccessStatus.GET_POST_STATS_SUCCESS, response);
+    }
+
+    @Operation(
             summary = "토큰 재발급 API",
             description = "엑세스 토큰 만료 시, 유효한 리프레시 토큰을 통해 엑세스 토큰을 재발급 받습니다."
     )

--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -69,7 +69,7 @@ public class MemberController {
 
     @Operation(
             summary = "사용자 정보 조회 API",
-            description = "토큰을 통해 인증된 사용자의 정보를 반환합니다." +
+            description = "토큰을 통해 인증된 사용자의 정보를 반환합니다. userId 쿼리 파라미터가 없으면 본인 정보를 조회하고, 있으면 해당 사용자의 정보를 조회합니다." +
                     "<br><br>[enum]독서 취향 유형 ->" +
                     "<br>- EMOTIONAL_REFLECTOR: 감성 사색 정리러" +
                     "<br>- CHATTY_READER: 수다쟁이 책러" +
@@ -85,8 +85,10 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
     })
     @GetMapping("/user-info")
-    public ResponseEntity<ApiResponse<UserInfoDTO>> getUserInfo(@AuthenticationPrincipal UserDetails userDetails){
-        UserInfoDTO response = memberService.getUserInfo(userDetails.getUsername());
+    public ResponseEntity<ApiResponse<UserInfoDTO>> getUserInfo(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) Long userId){
+        UserInfoDTO response = memberService.getUserInfo(userDetails.getUsername(), userId);
         return ApiResponse.success(SuccessStatus.GET_USERINFO_SUCCESS, response);
     }
 

--- a/src/main/java/com/moongeul/backend/api/member/dto/CategoryPostCountDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/CategoryPostCountDTO.java
@@ -1,0 +1,17 @@
+package com.moongeul.backend.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryPostCountDTO {
+
+    private Long categoryId; // 카테고리 ID
+    private String categoryTitle; // 카테고리 이름
+    private Integer postCount; // 해당 카테고리의 기록 갯수
+}

--- a/src/main/java/com/moongeul/backend/api/member/dto/PostStatsResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/PostStatsResponseDTO.java
@@ -1,0 +1,18 @@
+package com.moongeul.backend.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostStatsResponseDTO {
+
+    private Integer totalPostCount; // 전체 작성 갯수
+    private List<CategoryPostCountDTO> data; // 카테고리별 기록 갯수
+}

--- a/src/main/java/com/moongeul/backend/api/member/dto/UserInfoDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/UserInfoDTO.java
@@ -13,4 +13,6 @@ public class UserInfoDTO {
     private final String profileImage; // 회원 이미지
     private final String nickname; //닉네임 (초기랜덤생성)
     private ReadingTasteType readingTasteType; // 독서 취향 유형
+    private final Integer followerCount; // 팔로워 수
+    private final Integer followingCount; // 팔로잉 수
 }

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.entity.PrivacyLevel;
 import com.moongeul.backend.api.member.entity.Role;
 import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
+import com.moongeul.backend.api.member.repository.FollowRepository;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.api.member.util.NicknameGenerator;
 import com.moongeul.backend.common.config.jwt.JwtTokenProvider;
@@ -25,6 +26,7 @@ import java.util.UUID;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final GoogleOAuthService googleOAuthService;
     private final KakaoOAuthService kakaoOAuthService;
@@ -112,9 +114,22 @@ public class MemberService {
 
     // 사용자 정보 조회
     @Transactional(readOnly = true)
-    public UserInfoDTO getUserInfo(String email){
+    public UserInfoDTO getUserInfo(String email, Long userId){
 
-        Member member = getMemberByEmail(email);
+        // userId가 null이면 본인 정보 조회, 있으면 타 사용자 조회
+        Member member;
+        if (userId == null) {
+            member = getMemberByEmail(email);
+        } else {
+            member = memberRepository.findById(userId)
+                    .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+        }
+
+        // 팔로워 수 계산 (나를 팔로우하는 사람들 중 승인된 경우)
+        int followerCount = followRepository.findByFollowers(member.getId()).size();
+
+        // 팔로잉 수 계산 (내가 팔로우한 사람들 중 승인된 경우)
+        int followingCount = followRepository.findByFollowings(member.getId()).size();
 
         return UserInfoDTO.builder()
                 .id(member.getId())
@@ -122,6 +137,8 @@ public class MemberService {
                 .profileImage(member.getProfileImage())
                 .nickname(member.getNickname())
                 .readingTasteType(member.getReadingTasteType())
+                .followerCount(followerCount)
+                .followingCount(followingCount)
                 .build();
     }
 

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.moongeul.backend.api.member.service;
 
+import com.moongeul.backend.api.category.entity.Category;
+import com.moongeul.backend.api.category.repository.CategoryRepository;
 import com.moongeul.backend.api.member.dto.*;
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.entity.PrivacyLevel;
@@ -8,6 +10,7 @@ import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
 import com.moongeul.backend.api.member.repository.FollowRepository;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.api.member.util.NicknameGenerator;
+import com.moongeul.backend.api.post.repository.PostRepository;
 import com.moongeul.backend.common.config.jwt.JwtTokenProvider;
 import com.moongeul.backend.common.exception.BadRequestException;
 import com.moongeul.backend.common.exception.NotFoundException;
@@ -18,7 +21,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +33,8 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
+    private final CategoryRepository categoryRepository;
+    private final PostRepository postRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final GoogleOAuthService googleOAuthService;
     private final KakaoOAuthService kakaoOAuthService;
@@ -139,6 +147,47 @@ public class MemberService {
                 .readingTasteType(member.getReadingTasteType())
                 .followerCount(followerCount)
                 .followingCount(followingCount)
+                .build();
+    }
+
+    /* 기록 통계 조회 (마이페이지 기록장) */
+    public PostStatsResponseDTO getPostStats(String email, Long userId) {
+
+        // userId가 null이면 본인 정보 조회, 있으면 타 사용자 조회
+        Member member;
+        if (userId == null) {
+            member = getMemberByEmail(email);
+        } else {
+            member = memberRepository.findById(userId)
+                    .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+        }
+
+        Long memberId = member.getId();
+
+        // 전체 작성 갯수
+        int totalPostCount = (int) postRepository.countByMemberId(memberId);
+
+        // 해당 사용자가 만든 카테고리 목록 조회
+        List<Category> categories = categoryRepository.findByMember(member).orElse(new ArrayList<>());
+
+        // 카테고리별 기록 갯수 계산
+        List<CategoryPostCountDTO> categoryStats = categories.stream()
+                .map(category -> {
+                    int postCount = (int) postRepository.countByMemberIdAndCategoryId(memberId, category.getId());
+                    return CategoryPostCountDTO.builder()
+                            .categoryId(category.getId())
+                            .categoryTitle(category.getTitle())
+                            .postCount(postCount)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        log.info("기록 통계 조회 완료 - 사용자 ID: {}, 전체 기록 수: {}, 카테고리 수: {}",
+                memberId, totalPostCount, categoryStats.size());
+
+        return PostStatsResponseDTO.builder()
+                .totalPostCount(totalPostCount)
+                .data(categoryStats)
                 .build();
     }
 

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -10,19 +10,34 @@ import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
 import com.moongeul.backend.api.member.repository.FollowRepository;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.api.member.util.NicknameGenerator;
+import com.moongeul.backend.api.post.dto.CategoryPostDetailDTO;
+import com.moongeul.backend.api.post.dto.CategoryPostListResponseDTO;
+import com.moongeul.backend.api.post.dto.LikeStatsDTO;
+import com.moongeul.backend.api.post.dto.QuoteDTO;
+import com.moongeul.backend.api.post.entity.Likes;
+import com.moongeul.backend.api.post.entity.Post;
+import com.moongeul.backend.api.post.entity.Quote;
+import com.moongeul.backend.api.post.repository.LikeRepository;
 import com.moongeul.backend.api.post.repository.PostRepository;
+import com.moongeul.backend.api.post.repository.QuoteRepository;
+import com.moongeul.backend.api.book.entity.Book;
 import com.moongeul.backend.common.config.jwt.JwtTokenProvider;
 import com.moongeul.backend.common.exception.BadRequestException;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.exception.UnauthorizedException;
 import com.moongeul.backend.common.response.ErrorStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -35,6 +50,8 @@ public class MemberService {
     private final FollowRepository followRepository;
     private final CategoryRepository categoryRepository;
     private final PostRepository postRepository;
+    private final QuoteRepository quoteRepository;
+    private final LikeRepository likeRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final GoogleOAuthService googleOAuthService;
     private final KakaoOAuthService kakaoOAuthService;
@@ -262,6 +279,99 @@ public class MemberService {
 
         return NicknameCheckResponseDTO.builder()
                 .isDuplicate(isDuplicate)
+                .build();
+    }
+
+    // 카테고리별 기록 리스트 조회
+    @Transactional(readOnly = true)
+    public CategoryPostListResponseDTO getCategoryPostList(Long categoryId, String sortBy, Integer page, Integer size) {
+
+        // 카테고리 존재 여부 확인
+        categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage()));
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        // 정렬 조건에 따라 조회
+        Page<Post> postPage = switch (sortBy.toUpperCase()) {
+            case "LATEST" ->  // 최신순
+                    postRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
+            case "OLDEST" ->  // 오래된순
+                    postRepository.findByCategoryIdOrderByCreatedAtAsc(categoryId, pageable);
+            case "RATING_HIGH" ->  // 평점 높은순
+                    postRepository.findByCategoryIdOrderByRatingDesc(categoryId, pageable);
+            case "RATING_LOW" ->  // 평점 낮은순
+                    postRepository.findByCategoryIdOrderByRatingAsc(categoryId, pageable);
+            default ->  // 기본값: 최신순
+                    postRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
+        };
+
+        List<CategoryPostDetailDTO> postList = postPage.getContent().stream()
+                .map(this::convertToCategoryPostDetailDTO)
+                .collect(Collectors.toList());
+
+        log.info("카테고리별 기록 리스트 조회 완료 - 카테고리 ID: {}, 정렬: {}, 페이지: {}, 결과 수: {}",
+                categoryId, sortBy, page, postList.size());
+
+        return CategoryPostListResponseDTO.builder()
+                .total(postPage.getTotalElements())
+                .page(page)
+                .size(size)
+                .totalPages(postPage.getTotalPages())
+                .isLast(postPage.isLast())
+                .data(postList)
+                .build();
+    }
+
+    // Post를 CategoryPostDetailDTO로 변환
+    private CategoryPostDetailDTO convertToCategoryPostDetailDTO(Post post) {
+
+        Member member = post.getMember();
+        Book book = post.getBook();
+
+        // 인상깊은 구절 조회
+        List<Quote> quotes = quoteRepository.findByPostId(post.getId());
+        List<QuoteDTO> quoteDTOs = quotes.stream()
+                .map(quote -> QuoteDTO.builder()
+                        .quoteContent(quote.getQuoteContent())
+                        .pageNumber(quote.getPageNumber())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 공감 통계 계산
+        List<Likes> likes = likeRepository.findByPostId(post.getId());
+
+        Map<String, Integer> likeTypeCount = new HashMap<>();
+        likeTypeCount.put("RELATABLE", 0);
+        likeTypeCount.put("SAME_TASTE", 0);
+        likeTypeCount.put("IMPRESSIVE_EXPRESSION", 0);
+        likeTypeCount.put("WANT_TO_READ", 0);
+        likeTypeCount.put("HELPFUL", 0);
+
+        for (Likes like : likes) {
+            String likeTypeName = like.getLikeType().name();
+            likeTypeCount.put(likeTypeName, likeTypeCount.get(likeTypeName) + 1);
+        }
+
+        LikeStatsDTO likeStats = LikeStatsDTO.builder()
+                .likeTypeCount(likeTypeCount)
+                .build();
+
+        return CategoryPostDetailDTO.builder()
+                .postId(post.getId())
+                .profileImage(member.getProfileImage())
+                .nickname(member.getNickname())
+                .readingTasteType(member.getReadingTasteType())
+                .createdAt(post.getCreatedAt())
+                .content(post.getContent())
+                .userRating(post.getRating())
+                .readDate(post.getReadDate())
+                .bookImage(book.getBookImage())
+                .bookTitle(book.getTitle())
+                .publisher(book.getPublisher())
+                .bookRating(book.getRatingAverage())
+                .quotes(quoteDTOs)
+                .likeStats(likeStats)
                 .build();
     }
 }

--- a/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
+++ b/src/main/java/com/moongeul/backend/api/post/controller/PostController.java
@@ -173,3 +173,4 @@ public class PostController {
         return ApiResponse.success(SuccessStatus.GET_WEEKLY_RECOMMENDATION_SUCCESS, weeklyRecommendationResponseDTO);
     }
 }
+

--- a/src/main/java/com/moongeul/backend/api/post/dto/CategoryPostDetailDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/CategoryPostDetailDTO.java
@@ -1,0 +1,43 @@
+package com.moongeul.backend.api.post.dto;
+
+import com.moongeul.backend.api.member.entity.ReadingTasteType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryPostDetailDTO {
+
+    private Long postId; // 기록 ID
+
+    // 사용자 정보
+    private String profileImage; // 사용자 프로필 이미지
+    private String nickname; // 사용자 닉네임
+    private ReadingTasteType readingTasteType; // 독서 취향
+
+    // 기록 정보
+    private LocalDateTime createdAt; // 작성일
+    private String content; // 내용글
+    private Double userRating; // 사용자가 남긴 별점
+    private LocalDate readDate; // 읽은 날짜
+
+    // 책 정보
+    private String bookImage; // 책 사진
+    private String bookTitle; // 책 이름
+    private String publisher; // 출판사
+    private Double bookRating; // 책 별점
+
+    // 인상깊은 구절
+    private List<QuoteDTO> quotes; // 인상깊은 구절 리스트
+
+    // 공감 정보
+    private LikeStatsDTO likeStats; // 공감 통계
+}

--- a/src/main/java/com/moongeul/backend/api/post/dto/CategoryPostListResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/CategoryPostListResponseDTO.java
@@ -1,0 +1,22 @@
+package com.moongeul.backend.api.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryPostListResponseDTO {
+
+    private Long total; // 전체 검색 결과 수
+    private Integer page; // 현재 페이지
+    private Integer size; // 페이지당 개수
+    private Integer totalPages; // 전체 페이지 수
+    private Boolean isLast; // 마지막 페이지 여부
+    private List<CategoryPostDetailDTO> data; // 기록 리스트
+}

--- a/src/main/java/com/moongeul/backend/api/post/dto/LikeStatsDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/LikeStatsDTO.java
@@ -1,0 +1,17 @@
+package com.moongeul.backend.api.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LikeStatsDTO {
+
+    private Map<String, Integer> likeTypeCount; // 공감 유형별 갯수
+}

--- a/src/main/java/com/moongeul/backend/api/post/dto/QuoteDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/QuoteDTO.java
@@ -1,0 +1,16 @@
+package com.moongeul.backend.api.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuoteDTO {
+
+    private String quoteContent; // 인상깊은 구절 내용
+    private int pageNumber; // 페이지 번호
+}

--- a/src/main/java/com/moongeul/backend/api/post/repository/LikeRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/LikeRepository.java
@@ -3,9 +3,13 @@ package com.moongeul.backend.api.post.repository;
 import com.moongeul.backend.api.post.entity.Likes;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Likes, Long> {
 
     Optional<Likes> findByPostIdAndMemberId(Long postId, Long memberId);
+
+    // 특정 게시글의 모든 공감 조회
+    List<Likes> findByPostId(Long postId);
 }

--- a/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
@@ -35,4 +35,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findWeeklyRecommendationByReadingTasteType(
             @Param("readingTasteType") ReadingTasteType readingTasteType,
             @Param("weekStart") LocalDateTime weekStart);
+
+    // 특정 사용자의 전체 기록 수 조회
+    long countByMemberId(Long memberId);
+
+    // 특정 사용자의 카테고리별 기록 수 조회
+    long countByMemberIdAndCategoryId(Long memberId, Long categoryId);
 }

--- a/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
@@ -41,4 +41,20 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 특정 사용자의 카테고리별 기록 수 조회
     long countByMemberIdAndCategoryId(Long memberId, Long categoryId);
+
+    // 카테고리별 기록 조회 (최신순)
+    @Query("SELECT p FROM Post p WHERE p.category.id = :categoryId ORDER BY p.createdAt DESC")
+    Page<Post> findByCategoryIdOrderByCreatedAtDesc(@Param("categoryId") Long categoryId, Pageable pageable);
+
+    // 카테고리별 기록 조회 (오래된순)
+    @Query("SELECT p FROM Post p WHERE p.category.id = :categoryId ORDER BY p.createdAt ASC")
+    Page<Post> findByCategoryIdOrderByCreatedAtAsc(@Param("categoryId") Long categoryId, Pageable pageable);
+
+    // 카테고리별 기록 조회 (평점 높은순)
+    @Query("SELECT p FROM Post p WHERE p.category.id = :categoryId ORDER BY p.rating DESC, p.createdAt DESC")
+    Page<Post> findByCategoryIdOrderByRatingDesc(@Param("categoryId") Long categoryId, Pageable pageable);
+
+    // 카테고리별 기록 조회 (평점 낮은순)
+    @Query("SELECT p FROM Post p WHERE p.category.id = :categoryId ORDER BY p.rating ASC, p.createdAt DESC")
+    Page<Post> findByCategoryIdOrderByRatingAsc(@Param("categoryId") Long categoryId, Pageable pageable);
 }

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -17,6 +17,7 @@ public enum SuccessStatus {
 	/* MEMBER */
 	SEND_LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
 	GET_USERINFO_SUCCESS(HttpStatus.OK, "사용자 정보 조회 성공"),
+	GET_POST_STATS_SUCCESS(HttpStatus.OK, "기록 통계 조회 성공"),
 	REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
 	CALCULATE_READING_TASTE_SUCCESS(HttpStatus.OK, "독서 취향 테스트 결과 계산 성공"),
 	FOLLOW_SUCCESS(HttpStatus.OK, "팔로우 성공"),

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -45,6 +45,7 @@ public enum SuccessStatus {
 	/* POST */
 	GET_ALL_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 전체 조회 성공"),
 	GET_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 상세 조회 성공"),
+	GET_CATEGORY_POST_LIST_SUCCESS(HttpStatus.OK, "카테고리별 기록 리스트 조회 성공"),
 	UPDATE_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 수정 성공"),
 	DELETE_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 삭제 성공"),
 	POST_LIKE_SUCCESS(HttpStatus.OK, "기록(게시글) 공감 버튼 등록 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #53

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 사용자 정보 조회 API에서 팔로워, 팔로잉 숫자를 반환하도록 수정하였습니다, 또한 userId 를 받아서 타인의 정보를 조회할 수 있게 로직 수정하였습니다.
- 마이페이지에서 카테고리별 해당 사용자가 글을 작성한 갯수를 반환하는 기능을 구현하였습니다.
- 각 카테고리별 해당 사용자가 작성한 기록들을 조회하는 기능을 구현하였습니다. (다만 화면정의서에는 책 관련 정보가 반환되는걸로 적혀있는데 UI 에서는 책 정보 관련 정보가 안보여서 일단 중첩으로 구현을 해둔 상태이고 이건 추후 결정된 사항에 따라 수정 할 예정입니다.)

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 사용자 정보 조회 API ]
<img width="1430" height="590" alt="image" src="https://github.com/user-attachments/assets/132b7d9d-f8ee-4405-8adc-5158940a9856" />
<img width="1430" height="590" alt="image" src="https://github.com/user-attachments/assets/327dccad-a4d8-4658-8e12-5a6170c496f5" />

[ 기록장 관련 API ]
<img width="1430" height="116" alt="image" src="https://github.com/user-attachments/assets/936567db-a84f-4732-9d2f-bc7555e411d5" />
