### PR TITLE
[FIX] 기록 전체조회 API 필드 수정 & 로그인 response 필드 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/dto/LoginResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/LoginResponseDTO.java
@@ -14,4 +14,5 @@ public class LoginResponseDTO {
     private String role;
     private String accessToken; // JWT Access Token (우리 서버)
     private String refreshToken; // JWT Refresh Token (우리 서버)
+    private Boolean isReadingTaste; // 취향테스트 수행 여부
 }

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -81,10 +81,14 @@ public class MemberService {
         JwtTokenDTO jwtToken = jwtTokenProvider.generateToken(member);
         member.updateRefreshToken(jwtToken.getRefreshToken()); // 생성된 refreshToken DB 저장
 
+        // 5. 취향테스트 수행 여부
+        boolean isReadingTaste = (member.getReadingTasteType() != null);
+
         return LoginResponseDTO.builder()
                 .role(member.getAuthorityKey())
                 .accessToken(jwtToken.getAccessToken())
                 .refreshToken(jwtToken.getRefreshToken())
+                .isReadingTaste(isReadingTaste)
                 .build();
     }
 
@@ -110,10 +114,14 @@ public class MemberService {
         JwtTokenDTO jwtToken = jwtTokenProvider.generateToken(member);
         member.updateRefreshToken(jwtToken.getRefreshToken()); // 생성된 refreshToken DB 저장
 
+        // 5. 취향테스트 수행 여부
+        boolean isReadingTaste = (member.getReadingTasteType() != null);
+
         return LoginResponseDTO.builder()
                 .role(member.getAuthorityKey())
                 .accessToken(jwtToken.getAccessToken())
                 .refreshToken(jwtToken.getRefreshToken())
+                .isReadingTaste(isReadingTaste)
                 .build();
     }
 

--- a/src/main/java/com/moongeul/backend/api/post/dto/PostDTO.java
+++ b/src/main/java/com/moongeul/backend/api/post/dto/PostDTO.java
@@ -16,6 +16,8 @@ import java.util.List;
 @AllArgsConstructor
 public class PostDTO {
 
+    private Long postId; // 게시글 id
+
     private MemberInfo memberInfo; // 사용자 정보
     private LocalDateTime created; // 작성 시간
 
@@ -33,7 +35,7 @@ public class PostDTO {
     @Getter
     @Builder
     public static class MemberInfo {
-        private Long id;
+        private Long memberId;
         private String nickname; // 닉네임
         private String profileImage; // 회원 이미지
         private ReadingTasteType readingTasteType; // 독서 취향 유형

--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -148,7 +148,7 @@ public class PostService {
 
         // 멤버 정보(필요 정보만) DTO
         PostDTO.MemberInfo memberInfo = PostDTO.MemberInfo.builder()
-                .id(post.getMember().getId())
+                .memberId(post.getMember().getId())
                 .nickname(post.getMember().getNickname())
                 .profileImage(post.getMember().getProfileImage())
                 .readingTasteType(post.getMember().getReadingTasteType())
@@ -186,6 +186,7 @@ public class PostService {
                 .build();
 
         return PostDTO.builder()
+                .postId(postId)
                 .memberInfo(memberInfo)
                 .created(post.getCreatedAt())
                 .bookInfo(bookInfo)


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #55 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기록 전체조회 API 필드 수정 -> 각 기록의 postId 값을 추가했습니다.
  - 위 과정에서, 기존 id 였던 memberId의 필드명을 혼동을 방지하고자 memberId로 수정하였습니다.
- 로그인 response 필드 수정 -> 취향테스트 여부 boolean값을 추가합니다. (TRUE: 테스트 수행o / FALSE: 테스트 수행x)

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[기록 전체조회 API]
<img width="588" height="506" alt="image" src="https://github.com/user-attachments/assets/7267fb47-e1e3-407f-8930-0a95057baa36" />

[로그인 response - isReadingTaste 필드 추가]
<img width="453" height="296" alt="image" src="https://github.com/user-attachments/assets/2ebbaf84-d318-49af-afc2-08079c79acbe" />
-> 현재 취향테스트 수행 o -> isReadingTaste: true