### PR TITLE
[FIX] 도서 리뷰 조회 API 반환 필드 변경에 따른 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/book/dto/ReviewItemDTO.java
+++ b/src/main/java/com/moongeul/backend/api/book/dto/ReviewItemDTO.java
@@ -1,9 +1,15 @@
 package com.moongeul.backend.api.book.dto;
 
+import com.moongeul.backend.api.member.entity.ReadingTasteType;
+import com.moongeul.backend.api.post.dto.PostDTO;
+import com.moongeul.backend.api.post.dto.QuoteDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -12,7 +18,11 @@ import lombok.NoArgsConstructor;
 public class ReviewItemDTO {
     private Long postId; // 게시글 ID
     private String nickname; // 사용자 닉네임
+    private ReadingTasteType readingTasteType; // 독서 취향
+    private String profileImage; // 사용자 프로필 이미지
+    private LocalDateTime createdAt; // 작성 일자
     private Double rating; // 별점
     private String content; // 내용
+    private List<QuoteDTO> quotes; // 인상 깊은 구절들
+    private PostDTO.LikesInfo likesInfo; // 받은 감정 상태들(공감 통계)
 }
-

--- a/src/main/java/com/moongeul/backend/api/book/service/ReviewService.java
+++ b/src/main/java/com/moongeul/backend/api/book/service/ReviewService.java
@@ -4,7 +4,11 @@ import com.moongeul.backend.api.book.dto.ReviewItemDTO;
 import com.moongeul.backend.api.book.dto.ReviewResponseDTO;
 import com.moongeul.backend.api.book.entity.Book;
 import com.moongeul.backend.api.book.repository.BookRepository;
+import com.moongeul.backend.api.post.dto.PostDTO;
+import com.moongeul.backend.api.post.dto.QuoteDTO;
+import com.moongeul.backend.api.post.entity.Quote;
 import com.moongeul.backend.api.post.entity.Post;
+import com.moongeul.backend.api.post.repository.QuoteRepository;
 import com.moongeul.backend.api.post.repository.PostRepository;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.response.ErrorStatus;
@@ -26,6 +30,7 @@ public class ReviewService {
 
     private final PostRepository postRepository;
     private final BookRepository bookRepository;
+    private final QuoteRepository quoteRepository;
 
     // 리뷰 조회 (최신순) - Post 기반
     @Transactional(readOnly = true)
@@ -54,11 +59,32 @@ public class ReviewService {
     }
 
     private ReviewItemDTO convertToReviewItemDTO(Post post) {
+        List<Quote> quotes = quoteRepository.findByPostId(post.getId());
+        List<QuoteDTO> quoteDTOs = quotes.stream()
+                .map(quote -> QuoteDTO.builder()
+                        .quoteContent(quote.getQuoteContent())
+                        .pageNumber(quote.getPageNumber())
+                        .build())
+                .collect(Collectors.toList());
+
+        PostDTO.LikesInfo likesInfo = PostDTO.LikesInfo.builder()
+                .relatableCount(post.getRelatableCount())
+                .sameTasteCount(post.getSameTasteCount())
+                .impressiveExpressionCount(post.getImpressiveExpressionCount())
+                .wantToReadCount(post.getWantToReadCount())
+                .helpfulCount(post.getHelpfulCount())
+                .build();
+
         return ReviewItemDTO.builder()
                 .postId(post.getId())
                 .nickname(post.getMember().getNickname())
+                .readingTasteType(post.getMember().getReadingTasteType())
+                .profileImage(post.getMember().getProfileImage())
+                .createdAt(post.getCreatedAt())
                 .rating(post.getRating())
                 .content(post.getContent())
+                .quotes(quoteDTOs)
+                .likesInfo(likesInfo)
                 .build();
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #59

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- UI 디자인 변경에 따라 기존 필드 외에 추가된 필드를 반환하도록 수정하였습니다.
- 추가한 필드 목록)
- 1. 사용자 독서 취향(readingTasteType)
- 2. 사용자 프로필 사진(profileImage)
- 3. 작성 일자(createdAt)
- 4. 인상 깊은 구절(quotes)
- 5. 받은 감정 상태(likesInfo)

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 추가된 필드 ]
<img width="1291" height="398" alt="image" src="https://github.com/user-attachments/assets/7db46549-1d6e-43ee-9e69-3bfb9e056cfa" />
