### PR TITLE
[FIX] 타인 사용자 정보 조회 시 팔로우 여부 반환 추가

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -79,7 +79,11 @@ public class MemberController {
                     "<br>- IMMERSIVE_READER: 넷플릭스급 몰입러" +
                     "<br>- SECRET_DIARIST: 비밀 일기장 주인" +
                     "<br>- GENRE_SPECIALIST: 장르 고인물" +
-                    "<br>- RANDOM_PICKER: 랜덤 피커"
+                    "<br>- RANDOM_PICKER: 랜덤 피커" +
+                    "<br><br>[enum]myFollowStatus ->" +
+                    "<br>- NONE: 팔로우 아님" +
+                    "<br>- PENDING: 요청 대기중" +
+                    "<br>- ACCEPTED: 팔로우 완료"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),

--- a/src/main/java/com/moongeul/backend/api/member/dto/UserInfoDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/UserInfoDTO.java
@@ -1,5 +1,6 @@
 package com.moongeul.backend.api.member.dto;
 
+import com.moongeul.backend.api.member.entity.FollowStatus;
 import com.moongeul.backend.api.member.entity.ReadingTasteType;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,4 +16,5 @@ public class UserInfoDTO {
     private ReadingTasteType readingTasteType; // 독서 취향 유형
     private final Integer followerCount; // 팔로워 수
     private final Integer followingCount; // 팔로잉 수
+    private final FollowStatus myFollowStatus; // 내가 해당 사용자를 팔로우했는지 여부
 }

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -4,6 +4,8 @@ import com.moongeul.backend.api.category.entity.Category;
 import com.moongeul.backend.api.category.repository.CategoryRepository;
 import com.moongeul.backend.api.member.dto.*;
 import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.entity.Follow;
+import com.moongeul.backend.api.member.entity.FollowStatus;
 import com.moongeul.backend.api.member.entity.PrivacyLevel;
 import com.moongeul.backend.api.member.entity.Role;
 import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
@@ -149,10 +151,12 @@ public class MemberService {
     @Transactional(readOnly = true)
     public UserInfoDTO getUserInfo(String email, Long userId){
 
+        Member currentMember = getMemberByEmail(email);
+
         // userId가 null이면 본인 정보 조회, 있으면 타 사용자 조회
         Member member;
         if (userId == null) {
-            member = getMemberByEmail(email);
+            member = currentMember;
         } else {
             member = memberRepository.findById(userId)
                     .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
@@ -164,6 +168,14 @@ public class MemberService {
         // 팔로잉 수 계산 (내가 팔로우한 사람들 중 승인된 경우)
         int followingCount = followRepository.findByFollowings(member.getId()).size();
 
+        // 내가 해당 사용자를 팔로우했는지 여부
+        FollowStatus myFollowStatus = FollowStatus.NONE;
+        if (!currentMember.getId().equals(member.getId())) {
+            myFollowStatus = followRepository.findByFollowingIdAndFollowerId(member.getId(), currentMember.getId())
+                    .map(Follow::getFollowStatus)
+                    .orElse(FollowStatus.NONE);
+        }
+
         return UserInfoDTO.builder()
                 .id(member.getId())
                 .name(member.getName())
@@ -172,6 +184,7 @@ public class MemberService {
                 .readingTasteType(member.getReadingTasteType())
                 .followerCount(followerCount)
                 .followingCount(followingCount)
+                .myFollowStatus(myFollowStatus)
                 .build();
     }
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #64

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 타인 사용자 정보 조회 시 현재 자신이 이 사용자를 팔로우 한 상태인지 알려주는 필드를 추가하였습니다.

- 추가 필드 이름 : myFollowStatus
- NONE : 내 자신을 조회 / 팔로우 안한 사용자
- PENDING : 자신이 팔로우를 걸었지만 상대방이 아직 승인하지 않은 경우
- ACCEPTED : 자신과 상대방이 서로 팔로우 관계인 경우

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 응답 사진 ]
<img width="1291" height="250" alt="스크린샷 2026-02-05 오후 5 32 02" src="https://github.com/user-attachments/assets/e6b060f1-1ae2-47e4-b831-b35b3437b557" />