### PR TITLE
[FIX] 마이페이지 타 사용자 카테고리 별 전체 조회 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -112,7 +112,8 @@ public class MemberController {
 
     @Operation(
             summary = "카테고리별 기록 리스트 조회 API (마이페이지 기록장 상세)",
-            description = "특정 카테고리에 작성된 기록들을 조회합니다. 최신순, 오래된순, 평점 높은순, 평점 낮은순으로 정렬할 수 있습니다." +
+            description = "특정 카테고리에 작성된 기록들을 조회합니다. userId 쿼리 파라미터가 없으면 본인, 있으면 해당 사용자의 기록을 조회합니다. " +
+                    "최신순, 오래된순, 평점 높은순, 평점 낮은순으로 정렬할 수 있습니다." +
                     "<br><br>[enum] 정렬 옵션 (sortBy):" +
                     "<br>- LATEST: 최신순 (기본값)" +
                     "<br>- OLDEST: 오래된순" +
@@ -125,12 +126,15 @@ public class MemberController {
     })
     @GetMapping("/post-stats/{categoryId}")
     public ResponseEntity<ApiResponse<CategoryPostListResponseDTO>> getCategoryPostList(
+            @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long categoryId,
+            @RequestParam(required = false) Long userId,
             @RequestParam(defaultValue = "LATEST") String sortBy,
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "10") Integer size) {
 
-        CategoryPostListResponseDTO categoryPostListResponseDTO = memberService.getCategoryPostList(categoryId, sortBy, page, size);
+        CategoryPostListResponseDTO categoryPostListResponseDTO =
+                memberService.getCategoryPostList(userDetails.getUsername(), userId, categoryId, sortBy, page, size);
         return ApiResponse.success(SuccessStatus.GET_CATEGORY_POST_LIST_SUCCESS, categoryPostListResponseDTO);
     }
 

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -292,11 +292,22 @@ public class MemberService {
 
     // 카테고리별 기록 리스트 조회
     @Transactional(readOnly = true)
-    public CategoryPostListResponseDTO getCategoryPostList(Long categoryId, String sortBy, Integer page, Integer size) {
+    public CategoryPostListResponseDTO getCategoryPostList(String email, Long userId, Long categoryId, String sortBy, Integer page, Integer size) {
+
+        Member currentMember = getMemberByEmail(email);
+        Member targetMember = (userId == null)
+                ? currentMember
+                : memberRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
 
         // 카테고리 존재 여부 확인
-        categoryRepository.findById(categoryId)
+        Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage()));
+
+        // 카테고리 소유자 확인 (userId가 없으면 본인 기준)
+        if (!category.getMember().getId().equals(targetMember.getId())) {
+            throw new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage());
+        }
 
         Pageable pageable = PageRequest.of(page - 1, size);
 
@@ -318,8 +329,8 @@ public class MemberService {
                 .map(this::convertToCategoryPostDetailDTO)
                 .collect(Collectors.toList());
 
-        log.info("카테고리별 기록 리스트 조회 완료 - 카테고리 ID: {}, 정렬: {}, 페이지: {}, 결과 수: {}",
-                categoryId, sortBy, page, postList.size());
+        log.info("카테고리별 기록 리스트 조회 완료 - 카테고리 ID: {}, 사용자 ID: {}, 정렬: {}, 페이지: {}, 결과 수: {}",
+                categoryId, targetMember.getId(), sortBy, page, postList.size());
 
         return CategoryPostListResponseDTO.builder()
                 .total(postPage.getTotalElements())


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #66

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 마이페이지에서 타 사용자 카테고리 별 전체 조회 시 타사용자의 정보를 조회할 수 있도록 타 사용자 ID를 쿼리파라미터로 받아서 조회할 수 있도록 수정하였습니다.

- userId 값을 받을 경우 해당 사용자의 작성한 기록들을 반환합니다. 다만, 같이 전달받은 카테고리 ID값이 해당 사용자가 등록한 카테고리가 아닌 경우 예외처리 하도록 구현하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 내 정보 조회 ]
<img width="1390" height="580" alt="image" src="https://github.com/user-attachments/assets/11e72b51-0745-4ff4-8487-2e102ac35139" />


[ 타 정보 조회 ]
<img width="1390" height="580" alt="스크린샷 2026-02-05 오후 5 47 14" src="https://github.com/user-attachments/assets/3abeb9d2-dc3a-4338-8b0c-c702b7687e72" />
