### PR TITLE
[FEAT] 설정 - 이용 약관 동의 API

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -294,20 +294,20 @@ public class MemberController {
      * 약관동의 API
      *
      * */
-//    @Operation(
-//            summary = "이용약관동의 API",
-//            description = "이용약관 동의 여부를 저장합니다."
-//    )
-//    @ApiResponses({
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 중복 체크 성공")
-//    })
-//    @GetMapping("/agree-terms")
-//    public ResponseEntity<ApiResponse<NicknameCheckResponseDTO>> agreeToTerms(
-//            @AuthenticationPrincipal UserDetails userDetails,
-//            @RequestBody AgreeTermsRequestDTO agreeTermsRequestDTO) {
-//
-//        memberService.agreeToTerms(userDetails.getUsername(), agreeTermsRequestDTO);
-//        return ApiResponse.success(SuccessStatus.CHECK_NICKNAME_DUPLICATE_SUCCESS);
-//    }
+    @Operation(
+            summary = "이용약관동의 API",
+            description = "이용약관 동의 여부를 저장합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 중복 체크 성공")
+    })
+    @PostMapping("/agree-terms")
+    public ResponseEntity<ApiResponse<Void>> agreeToTerms(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody AgreeTermsRequestDTO agreeTermsRequestDTO) {
+
+        memberService.agreeToTerms(userDetails.getUsername(), agreeTermsRequestDTO);
+        return ApiResponse.success_only(SuccessStatus.TERMS_AGREE_SUCCESS);
+    }
     
 }

--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -288,5 +288,26 @@ public class MemberController {
         NicknameCheckResponseDTO nicknameCheckResponseDTO = memberService.checkNicknameDuplicate(nickname);
         return ApiResponse.success(SuccessStatus.CHECK_NICKNAME_DUPLICATE_SUCCESS, nicknameCheckResponseDTO);
     }
+
+    /*
+     *
+     * 약관동의 API
+     *
+     * */
+//    @Operation(
+//            summary = "이용약관동의 API",
+//            description = "이용약관 동의 여부를 저장합니다."
+//    )
+//    @ApiResponses({
+//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 중복 체크 성공")
+//    })
+//    @GetMapping("/agree-terms")
+//    public ResponseEntity<ApiResponse<NicknameCheckResponseDTO>> agreeToTerms(
+//            @AuthenticationPrincipal UserDetails userDetails,
+//            @RequestBody AgreeTermsRequestDTO agreeTermsRequestDTO) {
+//
+//        memberService.agreeToTerms(userDetails.getUsername(), agreeTermsRequestDTO);
+//        return ApiResponse.success(SuccessStatus.CHECK_NICKNAME_DUPLICATE_SUCCESS);
+//    }
     
 }

--- a/src/main/java/com/moongeul/backend/api/member/dto/AgreeTermsRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/AgreeTermsRequestDTO.java
@@ -1,0 +1,18 @@
+package com.moongeul.backend.api.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AgreeTermsRequestDTO {
+
+    private boolean serviceTermsAgree;
+    private boolean privatePolicyAgree;
+    private boolean marketingAgree;
+}

--- a/src/main/java/com/moongeul/backend/api/member/entity/Agree.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/Agree.java
@@ -28,4 +28,8 @@ public class Agree extends BaseTimeEntity {
     private Terms terms;
 
     private boolean isAgreed; // 동의 여부 (true/false)
+
+    public void updateAgreement(boolean isAgreed) {
+        this.isAgreed = isAgreed;
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/member/entity/Agree.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/Agree.java
@@ -1,0 +1,31 @@
+package com.moongeul.backend.api.member.entity;
+
+import com.moongeul.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder // 빌더 패턴 사용을 위한 롬복 애너테이션
+@NoArgsConstructor // 기본 생성자
+@AllArgsConstructor // 모든 필드를 포함한 생성자
+@Table(name = "AGREE") // 데이터베이스 테이블 이름 지정
+public class Agree extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "terms_id", nullable = false)
+    private Terms terms;
+
+    private boolean isAgreed; // 동의 여부 (true/false)
+}

--- a/src/main/java/com/moongeul/backend/api/member/entity/Terms.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/Terms.java
@@ -1,0 +1,27 @@
+package com.moongeul.backend.api.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder // 빌더 패턴 사용을 위한 롬복 애너테이션
+@NoArgsConstructor // 기본 생성자
+@AllArgsConstructor // 모든 필드를 포함한 생성자
+@Table(name = "TERMS") // 데이터베이스 테이블 이름 지정
+public class Terms {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private TermsType termsType; // 이용약관 타입
+
+    private String version; //v1.0, v1.1, v2.0 ...
+    private String content; // 약관 조항
+    private boolean isRequired; // 필수 여부
+}

--- a/src/main/java/com/moongeul/backend/api/member/entity/TermsType.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/TermsType.java
@@ -1,0 +1,15 @@
+package com.moongeul.backend.api.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TermsType {
+
+    SERVICE_TERMS_AGREE("서비스 이용약관 동의"),
+    PRIVACY_POLICY_AGREE("개인 정보 수집 및 이용 동의"),
+    MARKETING_AGREE("마케팅 정보 수신 동의");
+
+    private final String key;
+}

--- a/src/main/java/com/moongeul/backend/api/member/repository/AgreeRepository.java
+++ b/src/main/java/com/moongeul/backend/api/member/repository/AgreeRepository.java
@@ -1,0 +1,7 @@
+package com.moongeul.backend.api.member.repository;
+
+import com.moongeul.backend.api.member.entity.Agree;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AgreeRepository extends JpaRepository<Agree, Long> {
+}

--- a/src/main/java/com/moongeul/backend/api/member/repository/AgreeRepository.java
+++ b/src/main/java/com/moongeul/backend/api/member/repository/AgreeRepository.java
@@ -1,7 +1,13 @@
 package com.moongeul.backend.api.member.repository;
 
 import com.moongeul.backend.api.member.entity.Agree;
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.entity.Terms;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AgreeRepository extends JpaRepository<Agree, Long> {
+
+    Optional<Agree> findByMemberAndTerms(Member member, Terms terms);
 }

--- a/src/main/java/com/moongeul/backend/api/member/repository/TermsRepository.java
+++ b/src/main/java/com/moongeul/backend/api/member/repository/TermsRepository.java
@@ -1,0 +1,7 @@
+package com.moongeul.backend.api.member.repository;
+
+import com.moongeul.backend.api.member.entity.Terms;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+}

--- a/src/main/java/com/moongeul/backend/api/member/repository/TermsRepository.java
+++ b/src/main/java/com/moongeul/backend/api/member/repository/TermsRepository.java
@@ -1,7 +1,12 @@
 package com.moongeul.backend.api.member.repository;
 
 import com.moongeul.backend.api.member.entity.Terms;
+import com.moongeul.backend.api.member.entity.TermsType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TermsRepository extends JpaRepository<Terms, Long> {
+
+    Optional<Terms> findByTermsType(TermsType type);
 }

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -31,10 +31,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -430,46 +427,45 @@ public class MemberService {
      * 약관동의 API
      *
      * */
-//    public void agreeToTerms(String email, AgreeTermsRequestDTO agreeTermsRequestDTO){
-//
-//        Member member = getMemberByEmail(email);
-//
-//        // 예외처리: 필수 동의 여부 검증
-//        if (!agreeTermsRequestDTO.isServiceTermsAgree() || !agreeTermsRequestDTO.isPrivatePolicyAgree()) {
-//            throw new BadRequestException(ErrorStatus.DISAGREE_REQUIRED_TERM.getMessage());
-//        }
-//
-//        // 1. 약관 타입과 DTO의 동의 여부 매핑
-//        Map<TermsType, Boolean> agreementData = Map.of(
-//                TermsType.SERVICE_TERMS_AGREE, agreeTermsRequestDTO.isServiceTermsAgree(),
-//                TermsType.PRIVACY_POLICY_AGREE, agreeTermsRequestDTO.isPrivatePolicyAgree(),
-//                TermsType.MARKETING_AGREE, agreeTermsRequestDTO.isMarketingAgree()
-//        );
-//
-//        // 2. DB에서 각 타입에 맞는 Terms 정보를 찾아 Agree 엔티티 생성
-//        List<Agree> agrees = agreementData.entrySet().stream()
-//                .map(entry -> {
-//                    TermsType type = entry.getKey();
-//                    boolean isAgreed = entry.getValue();
-//
-//                    // DB에 미리 들어가 있는 약관 마스터 정보를 찾아옴
-//                    Terms terms = termsRepository.findByTermsType(type)
-//                            .orElseThrow(() -> new EntityNotFoundException(type.getKey() + " 약관 정보가 DB에 없습니다."));
-//
-//                    return Agree.builder()
-//                            .member(member)
-//                            .terms(terms)
-//                            .isAgreed(isAgreed)
-//                            .build();
-//                })
-//                .toList();
-//
-//        Agree.builder()
-//                .member(member)
-//                .terms()
-//                .isAgreed()
-//                .build();
-//    }
+    @Transactional
+    public void agreeToTerms(String email, AgreeTermsRequestDTO agreeTermsRequestDTO){
+
+        Member member = getMemberByEmail(email);
+
+        // 예외처리: 필수 동의 여부 검증
+        if (!agreeTermsRequestDTO.isServiceTermsAgree() || !agreeTermsRequestDTO.isPrivatePolicyAgree()) {
+            throw new BadRequestException(ErrorStatus.DISAGREE_REQUIRED_TERM.getMessage());
+        }
+
+        // 1. 약관 타입과 DTO의 동의 여부 매핑
+        Map<TermsType, Boolean> agreementData = Map.of(
+                TermsType.SERVICE_TERMS_AGREE, agreeTermsRequestDTO.isServiceTermsAgree(),
+                TermsType.PRIVACY_POLICY_AGREE, agreeTermsRequestDTO.isPrivatePolicyAgree(),
+                TermsType.MARKETING_AGREE, agreeTermsRequestDTO.isMarketingAgree()
+        );
+
+        agreementData.forEach((type, isAgreed) -> {
+            // 1. 해당 타입의 약관 마스터 정보 조회
+            Terms terms = termsRepository.findByTermsType(type)
+                    .orElseThrow(() -> new NotFoundException(ErrorStatus.TERMS_NOTFOUND_EXCEPTION.getMessage()));
+
+            // 2. 기존 동의 내역이 있는지 조회
+            agreeRepository.findByMemberAndTerms(member, terms)
+                    .ifPresentOrElse(
+                            // 이미 데이터가 있다면? -> 동의 여부 필드만 수정 (Dirty Checking 발생)
+                            existingAgree -> existingAgree.updateAgreement(isAgreed),
+                            // 데이터가 없다면? -> 새로 생성해서 저장
+                            () -> {
+                                Agree newAgree = Agree.builder()
+                                        .member(member)
+                                        .terms(terms)
+                                        .isAgreed(isAgreed)
+                                        .build();
+                                agreeRepository.save(newAgree);
+                            }
+                    );
+        });
+    }
 
     // 회원 조회 메서드
     private Member getMemberByEmail(String email) {

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -3,14 +3,12 @@ package com.moongeul.backend.api.member.service;
 import com.moongeul.backend.api.category.entity.Category;
 import com.moongeul.backend.api.category.repository.CategoryRepository;
 import com.moongeul.backend.api.member.dto.*;
-import com.moongeul.backend.api.member.entity.Follow;
-import com.moongeul.backend.api.member.entity.FollowStatus;
-import com.moongeul.backend.api.member.entity.Member;
-import com.moongeul.backend.api.member.entity.PrivacyLevel;
-import com.moongeul.backend.api.member.entity.Role;
+import com.moongeul.backend.api.member.entity.*;
 import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
+import com.moongeul.backend.api.member.repository.AgreeRepository;
 import com.moongeul.backend.api.member.repository.FollowRepository;
 import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.api.member.repository.TermsRepository;
 import com.moongeul.backend.api.member.util.NicknameGenerator;
 import com.moongeul.backend.api.post.dto.CategoryPostListResponseDTO;
 import com.moongeul.backend.api.post.dto.PostDTO;
@@ -35,6 +33,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -52,6 +51,8 @@ public class MemberService {
     private final GoogleOAuthService googleOAuthService;
     private final KakaoOAuthService kakaoOAuthService;
     private final NicknameGenerator nicknameGenerator;
+    private final TermsRepository termsRepository;
+    private final AgreeRepository agreeRepository;
 
     // 인가코드 받아 JWT로 교환 및 회원가입/로그인 처리
     @Transactional
@@ -221,11 +222,6 @@ public class MemberService {
                 .totalPostCount(totalPostCount)
                 .data(categoryStats)
                 .build();
-    }
-
-    private Member getMemberByEmail(String email) {
-        return memberRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
     }
 
     @Transactional
@@ -427,5 +423,57 @@ public class MemberService {
                 throw new ForbiddenException(ErrorStatus.PRIVACY_FORBIDDEN_EXCEPTION.getMessage());
             }
         }
+    }
+
+    /*
+     *
+     * 약관동의 API
+     *
+     * */
+//    public void agreeToTerms(String email, AgreeTermsRequestDTO agreeTermsRequestDTO){
+//
+//        Member member = getMemberByEmail(email);
+//
+//        // 예외처리: 필수 동의 여부 검증
+//        if (!agreeTermsRequestDTO.isServiceTermsAgree() || !agreeTermsRequestDTO.isPrivatePolicyAgree()) {
+//            throw new BadRequestException(ErrorStatus.DISAGREE_REQUIRED_TERM.getMessage());
+//        }
+//
+//        // 1. 약관 타입과 DTO의 동의 여부 매핑
+//        Map<TermsType, Boolean> agreementData = Map.of(
+//                TermsType.SERVICE_TERMS_AGREE, agreeTermsRequestDTO.isServiceTermsAgree(),
+//                TermsType.PRIVACY_POLICY_AGREE, agreeTermsRequestDTO.isPrivatePolicyAgree(),
+//                TermsType.MARKETING_AGREE, agreeTermsRequestDTO.isMarketingAgree()
+//        );
+//
+//        // 2. DB에서 각 타입에 맞는 Terms 정보를 찾아 Agree 엔티티 생성
+//        List<Agree> agrees = agreementData.entrySet().stream()
+//                .map(entry -> {
+//                    TermsType type = entry.getKey();
+//                    boolean isAgreed = entry.getValue();
+//
+//                    // DB에 미리 들어가 있는 약관 마스터 정보를 찾아옴
+//                    Terms terms = termsRepository.findByTermsType(type)
+//                            .orElseThrow(() -> new EntityNotFoundException(type.getKey() + " 약관 정보가 DB에 없습니다."));
+//
+//                    return Agree.builder()
+//                            .member(member)
+//                            .terms(terms)
+//                            .isAgreed(isAgreed)
+//                            .build();
+//                })
+//                .toList();
+//
+//        Agree.builder()
+//                .member(member)
+//                .terms()
+//                .isAgreed()
+//                .build();
+//    }
+
+    // 회원 조회 메서드
+    private Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
     }
 }

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -25,6 +25,7 @@ public enum ErrorStatus {
     INVALID_ANSWER_VALUE(HttpStatus.BAD_REQUEST, "테스트 답변은 A 또는 B여야 합니다. (질문번호: %d, 현재답변: %s)"),
     NO_SCORE_RESULT(HttpStatus.BAD_REQUEST, "테스트 점수 계산 결과가 없습니다."),
     REVIEW_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "수정하려는 회원의 리뷰가 아닙니다."),
+    DISAGREE_REQUIRED_TERM(HttpStatus.BAD_REQUEST, "필수 약관에 모두 동의해야 합니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -49,6 +49,7 @@ public enum ErrorStatus {
     WEEKLY_RECOMMENDATION_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "주간 추천 기록을 찾을 수 없습니다."),
     QUESTION_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 질문을 찾을 수 없습니다."),
     ANSWER_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 답변을 찾을 수 없습니다."),
+    TERMS_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "약관 정보를 찾을 수 없습니다."),
 
     /**
      * 400 BAD_REQUEST

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -29,6 +29,7 @@ public enum SuccessStatus {
 	CHECK_NICKNAME_DUPLICATE_SUCCESS(HttpStatus.OK, "닉네임 중복 체크 성공"),
 	GET_PRIVACY_LEVEL_SUCCESS(HttpStatus.OK, "계정 공개 범위 조회 성공"),
 	UPDATE_PRIVACY_LEVEL_SUCCESS(HttpStatus.OK, "계정 공개 범위 수정 성공"),
+	TERMS_AGREE_SUCCESS(HttpStatus.OK, "약관 동의 성공"),
 
 	/* BOOK */
 	SEARCH_BOOK_SUCCESS(HttpStatus.OK, "도서 검색 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #73 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 설정 도메인의 마케팅 정보 수신 동의 API를 구현하였습니다.
- 동일 API 사용으로 동의 여부 수정까지 가능합니다.
- member 테이블의 `is_marketing_allow` 같은 필드 구성(MVP용)이 아닌, 버전 관리와 동의 시각 파악(서비스 실질배포용)을 위해 테이블을 설계하여 구성하였습니다.
- DB구성
  - Agree 테이블: 사용자의 동의 여부와 동의 시각을 파악합니다.
  - Terms 테이블: 서비스 동의 내역에 대한 정보(버전 등)를 담고 있습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="870" height="481" alt="image" src="https://github.com/user-attachments/assets/cecbb999-78a2-4f96-ac55-18caf6450a80" />
