### PR TITLE
[FEAT] 읽은책 별점 간략/상세 조회 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/bookshelf/controller/DoneReadBookshelfController.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/controller/DoneReadBookshelfController.java
@@ -1,6 +1,7 @@
 package com.moongeul.backend.api.bookshelf.controller;
 
 import com.moongeul.backend.api.bookshelf.dto.DoneReadCalendarResponseDTO;
+import com.moongeul.backend.api.bookshelf.dto.DoneReadRatingSummaryResponseDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadBookshelfResponseDTO;
 import com.moongeul.backend.api.bookshelf.service.DoneReadBookshelfService;
 import com.moongeul.backend.common.response.ApiResponse;
@@ -64,5 +65,21 @@ public class DoneReadBookshelfController {
         DoneReadCalendarResponseDTO doneReadCalendar = doneReadBookshelfService.getDoneReadCalendar(
                 userDetails.getUsername(), year, month);
         return ApiResponse.success(SuccessStatus.GET_DONE_READ_CALENDAR_SUCCESS, doneReadCalendar);
+    }
+
+    @Operation(
+            summary = "읽은 책 별점 요약 조회 API",
+            description = "사용자가 기록한 총 책 수와 별점 구간(1.0~1.4, 1.5~1.9, ... , 4.5~5.0)별 기록 수를 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "읽은 책 별점 요약 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.")
+    })
+    @GetMapping("/rating-summary")
+    public ResponseEntity<ApiResponse<DoneReadRatingSummaryResponseDTO>> getDoneReadRatingSummary(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        DoneReadRatingSummaryResponseDTO doneReadRatingSummaryResponseDTO = doneReadBookshelfService.getDoneReadRatingSummary(userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.GET_DONE_READ_RATING_SUMMARY_SUCCESS, doneReadRatingSummaryResponseDTO);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/bookshelf/controller/DoneReadBookshelfController.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/controller/DoneReadBookshelfController.java
@@ -4,6 +4,7 @@ import com.moongeul.backend.api.bookshelf.dto.DoneReadCalendarResponseDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadRatingSummaryResponseDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadBookshelfResponseDTO;
 import com.moongeul.backend.api.bookshelf.service.DoneReadBookshelfService;
+import com.moongeul.backend.api.post.dto.CategoryPostListResponseDTO;
 import com.moongeul.backend.common.response.ApiResponse;
 import com.moongeul.backend.common.response.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -81,5 +82,34 @@ public class DoneReadBookshelfController {
 
         DoneReadRatingSummaryResponseDTO doneReadRatingSummaryResponseDTO = doneReadBookshelfService.getDoneReadRatingSummary(userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.GET_DONE_READ_RATING_SUMMARY_SUCCESS, doneReadRatingSummaryResponseDTO);
+    }
+
+    @Operation(
+            summary = "읽은 책 별점 구간 상세 조회 API",
+            description = "별점 구간(range)에 해당하는 기록 리스트를 조회합니다. " +
+                    "응답 형식은 카테고리별 기록 리스트 조회와 동일합니다." +
+                    "<br><br>예시 range: 1.0~1.4, 1.5~1.9, ... , 4.5~5.0" +
+                    "<br><br>[enum] 정렬 옵션 (sortBy):" +
+                    "<br>- LATEST: 최신순 (기본값)" +
+                    "<br>- OLDEST: 오래된순" +
+                    "<br>- RATING_HIGH: 평점 높은순" +
+                    "<br>- RATING_LOW: 평점 낮은순"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "읽은 책 별점 구간 상세 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 별점 구간입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.")
+    })
+    @GetMapping("/rating-summary/details")
+    public ResponseEntity<ApiResponse<CategoryPostListResponseDTO>> getDoneReadRatingDetail(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam String range,
+            @RequestParam(defaultValue = "LATEST") String sortBy,
+            @RequestParam(defaultValue = "1") @Min(value = 1, message = "페이지는 1 이상이어야 합니다.") Integer page,
+            @RequestParam(defaultValue = "10") @Min(value = 1, message = "한 페이지당 개수는 1 이상이어야 합니다.") Integer size) {
+
+        CategoryPostListResponseDTO categoryPostListResponseDTO =
+                doneReadBookshelfService.getDoneReadRatingDetail(userDetails.getUsername(), range, sortBy, page, size);
+        return ApiResponse.success(SuccessStatus.GET_DONE_READ_RATING_DETAIL_SUCCESS, categoryPostListResponseDTO);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/bookshelf/dto/DoneReadRatingRangeCountDTO.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/dto/DoneReadRatingRangeCountDTO.java
@@ -1,0 +1,15 @@
+package com.moongeul.backend.api.bookshelf.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DoneReadRatingRangeCountDTO {
+    private String range; // 별점 구간 (예: 1.0~1.4)
+    private Integer count; // 구간별 기록 수
+}

--- a/src/main/java/com/moongeul/backend/api/bookshelf/dto/DoneReadRatingSummaryResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/dto/DoneReadRatingSummaryResponseDTO.java
@@ -1,0 +1,17 @@
+package com.moongeul.backend.api.bookshelf.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DoneReadRatingSummaryResponseDTO {
+    private Long totalBooks; // 사용자가 기록한 총 책 수
+    private List<DoneReadRatingRangeCountDTO> data; // 별점 구간별 기록 수
+}

--- a/src/main/java/com/moongeul/backend/api/bookshelf/repository/DoneReadBookshelfRepository.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/repository/DoneReadBookshelfRepository.java
@@ -17,5 +17,6 @@ public interface DoneReadBookshelfRepository extends JpaRepository<DoneReadBooks
     
     @Query("SELECT d FROM DoneReadBookshelf d WHERE d.member = :member AND d.article.book = :book")
     Optional<DoneReadBookshelf> findByMemberAndBook(@Param("member") Member member, @Param("book") Book book);
-}
 
+    long countByMember(Member member);
+}

--- a/src/main/java/com/moongeul/backend/api/bookshelf/service/DoneReadBookshelfService.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/service/DoneReadBookshelfService.java
@@ -5,6 +5,8 @@ import com.moongeul.backend.api.bookshelf.dto.DoneReadCalendarDayDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadCalendarResponseDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadBookshelfItemDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadBookshelfResponseDTO;
+import com.moongeul.backend.api.bookshelf.dto.DoneReadRatingRangeCountDTO;
+import com.moongeul.backend.api.bookshelf.dto.DoneReadRatingSummaryResponseDTO;
 import com.moongeul.backend.api.bookshelf.entity.DoneReadBookshelf;
 import com.moongeul.backend.api.bookshelf.repository.DoneReadBookshelfRepository;
 import com.moongeul.backend.api.member.entity.Member;
@@ -24,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +39,12 @@ public class DoneReadBookshelfService {
     private final DoneReadBookshelfRepository doneReadBookshelfRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
+    private static final String[] RATING_RANGES = {
+            "1.0~1.4", "1.5~1.9", "2.0~2.4", "2.5~2.9",
+            "3.0~3.4", "3.5~3.9", "4.0~4.4", "4.5~5.0"
+    };
+    private static final double[] RANGE_STARTS = {1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5};
+    private static final double[] RANGE_ENDS = {1.4, 1.9, 2.4, 2.9, 3.4, 3.9, 4.4, 5.0};
 
     @Transactional(readOnly = true)
     public DoneReadBookshelfResponseDTO getDoneReadBooks(String email, Integer page, Integer size) {
@@ -134,6 +143,44 @@ public class DoneReadBookshelfService {
                 .year(year)
                 .month(month)
                 .data(calendarData)
+                .build();
+    }
+
+    // 읽은 책 별점 요약 조회
+    @Transactional(readOnly = true)
+    public DoneReadRatingSummaryResponseDTO getDoneReadRatingSummary(String email) {
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        long totalBooks = doneReadBookshelfRepository.countByMember(member);
+        List<Double> ratings = postRepository.findRatingsByMember(member);
+
+        int[] counts = new int[RATING_RANGES.length];
+        for (Double rating : ratings) {
+            if (rating == null) {
+                continue;
+            }
+
+            for (int i = 0; i < RATING_RANGES.length; i++) {
+                if (rating >= RANGE_STARTS[i] && rating <= RANGE_ENDS[i] + 1e-9) {
+                    counts[i]++;
+                    break;
+                }
+            }
+        }
+
+        List<DoneReadRatingRangeCountDTO> data = new ArrayList<>();
+        for (int i = 0; i < RATING_RANGES.length; i++) {
+            data.add(DoneReadRatingRangeCountDTO.builder()
+                    .range(RATING_RANGES[i])
+                    .count(counts[i])
+                    .build());
+        }
+
+        return DoneReadRatingSummaryResponseDTO.builder()
+                .totalBooks(totalBooks)
+                .data(data)
                 .build();
     }
 

--- a/src/main/java/com/moongeul/backend/api/bookshelf/service/DoneReadBookshelfService.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/service/DoneReadBookshelfService.java
@@ -11,8 +11,13 @@ import com.moongeul.backend.api.bookshelf.entity.DoneReadBookshelf;
 import com.moongeul.backend.api.bookshelf.repository.DoneReadBookshelfRepository;
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.api.post.dto.CategoryPostListResponseDTO;
+import com.moongeul.backend.api.post.dto.PostDTO;
 import com.moongeul.backend.api.post.entity.Post;
+import com.moongeul.backend.api.post.entity.Quote;
 import com.moongeul.backend.api.post.repository.PostRepository;
+import com.moongeul.backend.api.post.repository.QuoteRepository;
+import com.moongeul.backend.common.exception.BadRequestException;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +36,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -39,6 +46,7 @@ public class DoneReadBookshelfService {
     private final DoneReadBookshelfRepository doneReadBookshelfRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
+    private final QuoteRepository quoteRepository;
     private static final String[] RATING_RANGES = {
             "1.0~1.4", "1.5~1.9", "2.0~2.4", "2.5~2.9",
             "3.0~3.4", "3.5~3.9", "4.0~4.4", "4.5~5.0"
@@ -184,6 +192,37 @@ public class DoneReadBookshelfService {
                 .build();
     }
 
+    // 읽은 책 별점 구간 상세 조회
+    @Transactional(readOnly = true)
+    public CategoryPostListResponseDTO getDoneReadRatingDetail(String email, String range, String sortBy, Integer page, Integer size) {
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        int rangeIndex = findRangeIndex(range);
+        Pageable pageable = PageRequest.of(page - 1, size, resolveSort(sortBy));
+
+        Page<Post> postPage = postRepository.findByMemberAndRatingBetween(
+                member,
+                RANGE_STARTS[rangeIndex],
+                RANGE_ENDS[rangeIndex],
+                pageable
+        );
+
+        List<PostDTO> postList = postPage.getContent().stream()
+                .map(this::convertToPostDTO)
+                .collect(Collectors.toList());
+
+        return CategoryPostListResponseDTO.builder()
+                .total(postPage.getTotalElements())
+                .page(page)
+                .size(size)
+                .totalPages(postPage.getTotalPages())
+                .isLast(postPage.isLast())
+                .data(postList)
+                .build();
+    }
+
     private DoneReadBookshelfItemDTO convertToItemDTO(DoneReadBookshelf doneReadBookshelf) {
         Book book = doneReadBookshelf.getArticle().getBook();
         
@@ -197,6 +236,86 @@ public class DoneReadBookshelfService {
                 .height(doneReadBookshelf.getHeight())
                 .postCount(doneReadBookshelf.getPostCount())
                 .build();
+    }
+
+    private PostDTO convertToPostDTO(Post post) {
+
+        Book book = post.getBook();
+
+        PostDTO.MemberInfo memberInfo = PostDTO.MemberInfo.builder()
+                .memberId(post.getMember().getId())
+                .nickname(post.getMember().getNickname())
+                .profileImage(post.getMember().getProfileImage())
+                .readingTasteType(post.getMember().getReadingTasteType())
+                .build();
+
+        PostDTO.BookInfo bookInfo = PostDTO.BookInfo.builder()
+                .isbn(book.getIsbn())
+                .bookImage(book.getBookImage())
+                .title(book.getTitle())
+                .author(book.getAuthor())
+                .publisher(book.getPublisher())
+                .pubdate(book.getPubdate())
+                .ratingAverage(book.getRatingAverage())
+                .build();
+
+        List<Quote> quotes = quoteRepository.findByPostId(post.getId());
+        List<PostDTO.QuoteDTO> quoteDTOList = quotes.stream()
+                .map(quote -> PostDTO.QuoteDTO.builder()
+                        .quoteContent(quote.getQuoteContent())
+                        .pageNumber(quote.getPageNumber())
+                        .build())
+                .collect(Collectors.toList());
+
+        PostDTO.LikesCnt likesCnt = PostDTO.LikesCnt.builder()
+                .relatableCount(post.getRelatableCount())
+                .sameTasteCount(post.getSameTasteCount())
+                .impressiveExpressionCount(post.getImpressiveExpressionCount())
+                .wantToReadCount(post.getWantToReadCount())
+                .helpfulCount(post.getHelpfulCount())
+                .build();
+
+        return PostDTO.builder()
+                .postId(post.getId())
+                .memberInfo(memberInfo)
+                .created(post.getCreatedAt())
+                .bookInfo(bookInfo)
+                .rating(post.getRating())
+                .content(post.getContent())
+                .readDate(post.getReadDate())
+                .quotesCnt(quoteDTOList.size())
+                .quotes(quoteDTOList)
+                .likesCnt(likesCnt)
+                .build();
+    }
+
+    private Sort resolveSort(String sortBy) {
+        if (sortBy == null) {
+            return Sort.by(Sort.Order.desc("createdAt"));
+        }
+
+        return switch (sortBy.toUpperCase()) {
+            case "OLDEST" -> Sort.by(Sort.Order.asc("createdAt"));
+            case "RATING_HIGH" -> Sort.by(Sort.Order.desc("rating"), Sort.Order.desc("createdAt"));
+            case "RATING_LOW" -> Sort.by(Sort.Order.asc("rating"), Sort.Order.desc("createdAt"));
+            case "LATEST" -> Sort.by(Sort.Order.desc("createdAt"));
+            default -> Sort.by(Sort.Order.desc("createdAt"));
+        };
+    }
+
+    private int findRangeIndex(String range) {
+        if (range == null) {
+            throw new BadRequestException(ErrorStatus.INVALID_RATING_RANGE_EXCEPTION.getMessage());
+        }
+
+        String normalizedRange = range.replace(" ", "");
+        for (int i = 0; i < RATING_RANGES.length; i++) {
+            if (RATING_RANGES[i].equals(normalizedRange)) {
+                return i;
+            }
+        }
+
+        throw new BadRequestException(ErrorStatus.INVALID_RATING_RANGE_EXCEPTION.getMessage());
     }
 
     private static class CalendarDayAggregate {

--- a/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
@@ -83,4 +83,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // 사용자 별점 목록 조회 (null 제외)
     @Query("SELECT p.rating FROM Post p WHERE p.member = :member AND p.rating IS NOT NULL")
     List<Double> findRatingsByMember(@Param("member") Member member);
+
+    Page<Post> findByMemberAndRatingBetween(Member member, Double startRating, Double endRating, Pageable pageable);
 }

--- a/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
@@ -79,4 +79,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             @Param("member") Member member,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate);
+
+    // 사용자 별점 목록 조회 (null 제외)
+    @Query("SELECT p.rating FROM Post p WHERE p.member = :member AND p.rating IS NOT NULL")
+    List<Double> findRatingsByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -61,6 +61,7 @@ public enum ErrorStatus {
     NO_FOLLOW_RELATIONSHIP(HttpStatus.BAD_REQUEST, "팔로우 관계가 존재하지 않습니다."),
     EXISTS_FOLLOW_ACCEPTED(HttpStatus.BAD_REQUEST, "이미 팔로우하고 있는 사용자입니다."),
     EXISTS_FOLLOW_PENDING(HttpStatus.BAD_REQUEST, "이미 팔로우 요청을 보냈습니다. 승인을 기다려주세요."),
+    INVALID_RATING_RANGE_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 별점 구간입니다."),
     PRIVACY_FORBIDDEN_EXCEPTION(HttpStatus.FORBIDDEN, "해당 사용자의 정보는 공개되지 않습니다."),
 
     /**

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -45,6 +45,7 @@ public enum SuccessStatus {
 	GET_WISH_READ_BOOKS_SUCCESS(HttpStatus.OK, "읽고 싶은 책장 조회 성공"),
 	GET_DONE_READ_BOOKS_SUCCESS(HttpStatus.OK, "읽은 책장 조회 성공"),
 	GET_DONE_READ_CALENDAR_SUCCESS(HttpStatus.OK, "읽은 책 캘린더 조회 성공"),
+	GET_DONE_READ_RATING_SUMMARY_SUCCESS(HttpStatus.OK, "읽은 책 별점 요약 조회 성공"),
 
 	/* POST */
 	GET_ALL_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 전체 조회 성공"),

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -46,6 +46,7 @@ public enum SuccessStatus {
 	GET_DONE_READ_BOOKS_SUCCESS(HttpStatus.OK, "읽은 책장 조회 성공"),
 	GET_DONE_READ_CALENDAR_SUCCESS(HttpStatus.OK, "읽은 책 캘린더 조회 성공"),
 	GET_DONE_READ_RATING_SUMMARY_SUCCESS(HttpStatus.OK, "읽은 책 별점 요약 조회 성공"),
+	GET_DONE_READ_RATING_DETAIL_SUCCESS(HttpStatus.OK, "읽은 책 별점 구간 상세 조회 성공"),
 
 	/* POST */
 	GET_ALL_POST_SUCCESS(HttpStatus.OK, "기록(게시글) 전체 조회 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #86 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 읽은책 에서 0.5 구간 별로 등록한 책들을 간단하게 조회 하는 기능을 구현하였습니다.
- 해당 구간을 누르면 해당 구간의 기록들을 상세하게 조회할 수 있는 기능을 구현하였습니다.

P.S 별점 상세 페이지에서 필터링 조건이 피그마 UI or 화면정의서에 관련 내용이 없어서 일단은 최신순, 오래된순, 별점 높은순, 별점 낮은순 이렇게 4개로 구현해둔 상태입니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 별점 간략 조회 ]
<img width="1405" height="686" alt="image" src="https://github.com/user-attachments/assets/fc64b624-5b24-4a7f-9c2a-8bdc2f3fe978" />

[ 별점 상세 조회 ]
<img width="1405" height="701" alt="image" src="https://github.com/user-attachments/assets/53215e07-a4a0-4ab2-871c-08d49e8be616" />
