### PR TITLE
[FEAT] 알림 페이지 API 구현

### DIFF
--- a/hs_err_pid21744.log
+++ b/hs_err_pid21744.log
@@ -1,0 +1,766 @@
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 76546048 bytes for G1 virtual space
+# Possible reasons:
+#   The system is out of physical RAM or swap space
+#   The process is running with CompressedOops enabled, and the Java Heap may be blocking the growth of the native heap
+# Possible solutions:
+#   Reduce memory load on the system
+#   Increase physical memory or swap space
+#   Check if swap backing store is full
+#   Decrease Java heap size (-Xmx/-Xms)
+#   Decrease number of Java threads
+#   Decrease Java thread stack sizes (-Xss)
+#   Set larger code cache with -XX:ReservedCodeCacheSize=
+#   JVM is running with Unscaled Compressed Oops mode in which the Java heap is
+#     placed in the first 4GB address space. The Java Heap base address is the
+#     maximum limit for the native heap growth. Please use -XX:HeapBaseMinAddress
+#     to set the Java Heap base and to place the Java Heap above 4GB virtual address.
+# This output file may be truncated or incomplete.
+#
+#  Out of Memory Error (os_windows.cpp:3548), pid=21744, tid=1196
+#
+# JRE version: Java(TM) SE Runtime Environment (17.0.11+7) (build 17.0.11+7-LTS-207)
+# Java VM: Java HotSpot(TM) 64-Bit Server VM (17.0.11+7-LTS-207, mixed mode, emulated-client, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, windows-amd64)
+# No core dump will be written. Minidumps are not enabled by default on client versions of Windows
+#
+
+---------------  S U M M A R Y ------------
+
+Command Line: -XX:TieredStopAtLevel=1 -Dspring.output.ansi.enabled=always -Dcom.sun.management.jmxremote -Dspring.jmx.enabled=true -Dspring.liveBeansView.mbeanDomain -Dspring.application.admin.enabled=true -Dmanagement.endpoints.jmx.exposure.include=* -javaagent:C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.1\lib\idea_rt.jar=59265:C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.1\bin -Dfile.encoding=UTF-8 com.moongeul.backend.BackendApplication
+
+Host: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz, 8 cores, 7G,  Windows 11 , 64 bit Build 26100 (10.0.26100.7705)
+Time: Tue Feb 17 18:40:06 2026  Windows 11 , 64 bit Build 26100 (10.0.26100.7705) elapsed time: 60.511109 seconds (0d 0h 1m 0s)
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x0000019a297e15b0):  VMThread "VM Thread" [stack: 0x0000000d72800000,0x0000000d72900000] [id=1196]
+
+Stack: [0x0000000d72800000,0x0000000d72900000]
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+V  [jvm.dll+0x679cca]
+V  [jvm.dll+0x7da13d]
+V  [jvm.dll+0x7dba83]
+V  [jvm.dll+0x7dc0f3]
+V  [jvm.dll+0x2449af]
+V  [jvm.dll+0x676ce9]
+V  [jvm.dll+0x66b852]
+V  [jvm.dll+0x3018d6]
+V  [jvm.dll+0x308e76]
+V  [jvm.dll+0x3596ee]
+V  [jvm.dll+0x35991f]
+V  [jvm.dll+0x2d89a8]
+V  [jvm.dll+0x2d6ddd]
+V  [jvm.dll+0x2d642c]
+V  [jvm.dll+0x319f8b]
+V  [jvm.dll+0x7e09eb]
+V  [jvm.dll+0x7e1724]
+V  [jvm.dll+0x7e1c3d]
+V  [jvm.dll+0x7e2014]
+V  [jvm.dll+0x7e20e0]
+V  [jvm.dll+0x78a85a]
+V  [jvm.dll+0x678bb5]
+C  [ucrtbase.dll+0x37b0]
+C  [KERNEL32.DLL+0x2e8d7]
+C  [ntdll.dll+0x8c40c]
+
+VM_Operation (0x0000000d722faf10): G1CollectForAllocation, mode: safepoint, requested by thread 0x0000019a15aa28c0
+
+
+---------------  P R O C E S S  ---------------
+
+Threads class SMR info:
+_java_thread_list=0x0000019a7149b5f0, length=21, elements={
+0x0000019a15aa28c0, 0x0000019a297e7670, 0x0000019a297ec050, 0x0000019a29801070,
+0x0000019a29801940, 0x0000019a29802300, 0x0000019a29802cc0, 0x0000019a29803680,
+0x0000019a29832ce0, 0x0000019a297d3100, 0x0000019a6f28acf0, 0x0000019a6f28b1d0,
+0x0000019a6f40d5c0, 0x0000019a6f574dd0, 0x0000019a29976700, 0x0000019a6f3e82b0,
+0x0000019a6f3e87c0, 0x0000019a6f3e8cd0, 0x0000019a6f3e91e0, 0x0000019a70d661e0,
+0x0000019a716de800
+}
+
+Java Threads: ( => current thread )
+  0x0000019a15aa28c0 JavaThread "main" [_thread_blocked, id=19796, stack(0x0000000d72200000,0x0000000d72300000)]
+  0x0000019a297e7670 JavaThread "Reference Handler" daemon [_thread_blocked, id=10308, stack(0x0000000d72900000,0x0000000d72a00000)]
+  0x0000019a297ec050 JavaThread "Finalizer" daemon [_thread_blocked, id=28868, stack(0x0000000d72a00000,0x0000000d72b00000)]
+  0x0000019a29801070 JavaThread "Signal Dispatcher" daemon [_thread_blocked, id=21932, stack(0x0000000d72b00000,0x0000000d72c00000)]
+  0x0000019a29801940 JavaThread "Attach Listener" daemon [_thread_blocked, id=3744, stack(0x0000000d72c00000,0x0000000d72d00000)]
+  0x0000019a29802300 JavaThread "Service Thread" daemon [_thread_blocked, id=14168, stack(0x0000000d72d00000,0x0000000d72e00000)]
+  0x0000019a29802cc0 JavaThread "Monitor Deflation Thread" daemon [_thread_blocked, id=22684, stack(0x0000000d72e00000,0x0000000d72f00000)]
+  0x0000019a29803680 JavaThread "C1 CompilerThread0" daemon [_thread_blocked, id=20676, stack(0x0000000d72f00000,0x0000000d73000000)]
+  0x0000019a29832ce0 JavaThread "Sweeper thread" daemon [_thread_blocked, id=22920, stack(0x0000000d73000000,0x0000000d73100000)]
+  0x0000019a297d3100 JavaThread "Common-Cleaner" daemon [_thread_blocked, id=12932, stack(0x0000000d73100000,0x0000000d73200000)]
+  0x0000019a6f28acf0 JavaThread "Monitor Ctrl-Break" daemon [_thread_in_native, id=18956, stack(0x0000000d73400000,0x0000000d73500000)]
+  0x0000019a6f28b1d0 JavaThread "Notification Thread" daemon [_thread_blocked, id=22604, stack(0x0000000d73500000,0x0000000d73600000)]
+  0x0000019a6f40d5c0 JavaThread "RMI TCP Accept-0" daemon [_thread_in_native, id=6208, stack(0x0000000d73600000,0x0000000d73700000)]
+  0x0000019a6f574dd0 JavaThread "RMI TCP Connection(1)-192.168.219.104" daemon [_thread_blocked, id=17152, stack(0x0000000d74100000,0x0000000d74200000)]
+  0x0000019a29976700 JavaThread "RMI Scheduler(0)" daemon [_thread_blocked, id=15100, stack(0x0000000d74200000,0x0000000d74300000)]
+  0x0000019a6f3e82b0 JavaThread "Catalina-utility-1" [_thread_blocked, id=4660, stack(0x0000000d74400000,0x0000000d74500000)]
+  0x0000019a6f3e87c0 JavaThread "Catalina-utility-2" [_thread_blocked, id=2400, stack(0x0000000d74500000,0x0000000d74600000)]
+  0x0000019a6f3e8cd0 JavaThread "container-0" [_thread_blocked, id=28584, stack(0x0000000d74600000,0x0000000d74700000)]
+  0x0000019a6f3e91e0 JavaThread "HikariPool-1:housekeeper" daemon [_thread_blocked, id=1008, stack(0x0000000d74700000,0x0000000d74800000)]
+  0x0000019a70d661e0 JavaThread "C1 CompilerThread1" daemon [_thread_blocked, id=24516, stack(0x0000000d74900000,0x0000000d74a00000)]
+  0x0000019a716de800 JavaThread "C1 CompilerThread2" daemon [_thread_blocked, id=12740, stack(0x0000000d74800000,0x0000000d74900000)]
+
+Other Threads:
+=>0x0000019a297e15b0 VMThread "VM Thread" [stack: 0x0000000d72800000,0x0000000d72900000] [id=1196]
+  0x0000019a6f402de0 WatcherThread [stack: 0x0000000d73700000,0x0000000d73800000] [id=16244]
+  0x0000019a15afcae0 GCTaskThread "GC Thread#0" [stack: 0x0000000d72300000,0x0000000d72400000] [id=14500]
+  0x0000019a6f687a70 GCTaskThread "GC Thread#1" [stack: 0x0000000d73800000,0x0000000d73900000] [id=4060]
+  0x0000019a6f74b500 GCTaskThread "GC Thread#2" [stack: 0x0000000d73900000,0x0000000d73a00000] [id=25556]
+  0x0000019a6f74b7c0 GCTaskThread "GC Thread#3" [stack: 0x0000000d73a00000,0x0000000d73b00000] [id=13016]
+  0x0000019a6f74ba80 GCTaskThread "GC Thread#4" [stack: 0x0000000d73b00000,0x0000000d73c00000] [id=25464]
+  0x0000019a6f74bd40 GCTaskThread "GC Thread#5" [stack: 0x0000000d73c00000,0x0000000d73d00000] [id=18884]
+  0x0000019a6fc13090 GCTaskThread "GC Thread#6" [stack: 0x0000000d73300000,0x0000000d73400000] [id=24304]
+  0x0000019a6fc13350 GCTaskThread "GC Thread#7" [stack: 0x0000000d73e00000,0x0000000d73f00000] [id=5208]
+  0x0000019a15b0d030 ConcurrentGCThread "G1 Main Marker" [stack: 0x0000000d72400000,0x0000000d72500000] [id=6236]
+  0x0000019a15b0da40 ConcurrentGCThread "G1 Conc#0" [stack: 0x0000000d72500000,0x0000000d72600000] [id=17436]
+  0x0000019a6ff6f1d0 ConcurrentGCThread "G1 Conc#1" [stack: 0x0000000d74300000,0x0000000d74400000] [id=9704]
+  0x0000019a15b4e8a0 ConcurrentGCThread "G1 Refine#0" [stack: 0x0000000d72600000,0x0000000d72700000] [id=6400]
+  0x0000019a6f3aed50 ConcurrentGCThread "G1 Refine#1" [stack: 0x0000000d73d00000,0x0000000d73e00000] [id=24320]
+  0x0000019a2968f380 ConcurrentGCThread "G1 Service" [stack: 0x0000000d72700000,0x0000000d72800000] [id=26236]
+
+Threads with active compile tasks:
+
+VM state: at safepoint (normal execution)
+
+VM Mutex/Monitor currently owned by a thread:  ([mutex/lock_event])
+[0x0000019a15a9ea50] Threads_lock - owner thread: 0x0000019a297e15b0
+[0x0000019a15a9e300] Heap_lock - owner thread: 0x0000019a15aa28c0
+
+Heap address: 0x0000000085000000, size: 1968 MB, Compressed Oops mode: 32-bit
+
+CDS archive(s) mapped at: [0x0000019a2a000000-0x0000019a2abd0000-0x0000019a2abd0000), size 12386304, SharedBaseAddress: 0x0000019a2a000000, ArchiveRelocationMode: 1.
+Compressed class space mapped at: 0x0000019a2b000000-0x0000019a6b000000, reserved size: 1073741824
+Narrow klass base: 0x0000019a2a000000, Narrow klass shift: 0, Narrow klass range: 0x100000000
+
+GC Precious Log:
+ CPUs: 8 total, 8 available
+ Memory: 7865M
+ Large Page Support: Disabled
+ NUMA Support: Disabled
+ Compressed Oops: Enabled (32-bit)
+ Heap Region Size: 1M
+ Heap Min Capacity: 8M
+ Heap Initial Capacity: 124M
+ Heap Max Capacity: 1968M
+ Pre-touch: Disabled
+ Parallel Workers: 8
+ Concurrent Workers: 2
+ Concurrent Refinement Workers: 8
+ Periodic GC: Disabled
+
+Heap:
+ garbage-first heap   total 126976K, used 56320K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 3 young (3072K), 3 survivors (3072K)
+ Metaspace       used 74640K, committed 75264K, reserved 1114112K
+  class space    used 11113K, committed 11392K, reserved 1048576K
+
+Heap Regions: E=young(eden), S=young(survivor), O=old, HS=humongous(starts), HC=humongous(continues), CS=collection set, F=free, OA=open archive, CA=closed archive, TAMS=top-at-mark-start (previous, next)
+|   0|0x0000000085000000, 0x0000000085100000, 0x0000000085100000|100%|HS|  |TAMS 0x0000000085100000, 0x0000000085100000| Complete 
+|   1|0x0000000085100000, 0x0000000085200000, 0x0000000085200000|100%|HS|  |TAMS 0x0000000085200000, 0x0000000085200000| Complete 
+|   2|0x0000000085200000, 0x0000000085300000, 0x0000000085300000|100%| O|  |TAMS 0x0000000085300000, 0x0000000085300000| Untracked 
+|   3|0x0000000085300000, 0x0000000085400000, 0x0000000085400000|100%| O|  |TAMS 0x0000000085400000, 0x0000000085400000| Untracked 
+|   4|0x0000000085400000, 0x0000000085500000, 0x0000000085500000|100%| O|  |TAMS 0x0000000085500000, 0x0000000085500000| Untracked 
+|   5|0x0000000085500000, 0x0000000085600000, 0x0000000085600000|100%| O|  |TAMS 0x0000000085600000, 0x0000000085600000| Untracked 
+|   6|0x0000000085600000, 0x0000000085700000, 0x0000000085700000|100%| O|  |TAMS 0x0000000085700000, 0x0000000085700000| Untracked 
+|   7|0x0000000085700000, 0x0000000085800000, 0x0000000085800000|100%| O|  |TAMS 0x0000000085800000, 0x0000000085800000| Untracked 
+|   8|0x0000000085800000, 0x0000000085900000, 0x0000000085900000|100%| O|  |TAMS 0x0000000085900000, 0x0000000085900000| Untracked 
+|   9|0x0000000085900000, 0x0000000085a00000, 0x0000000085a00000|100%| O|  |TAMS 0x0000000085a00000, 0x0000000085a00000| Untracked 
+|  10|0x0000000085a00000, 0x0000000085b00000, 0x0000000085b00000|100%| O|  |TAMS 0x0000000085b00000, 0x0000000085b00000| Untracked 
+|  11|0x0000000085b00000, 0x0000000085c00000, 0x0000000085c00000|100%| O|  |TAMS 0x0000000085c00000, 0x0000000085c00000| Untracked 
+|  12|0x0000000085c00000, 0x0000000085d00000, 0x0000000085d00000|100%| O|  |TAMS 0x0000000085d00000, 0x0000000085d00000| Untracked 
+|  13|0x0000000085d00000, 0x0000000085e00000, 0x0000000085e00000|100%| O|  |TAMS 0x0000000085e00000, 0x0000000085e00000| Untracked 
+|  14|0x0000000085e00000, 0x0000000085f00000, 0x0000000085f00000|100%| O|  |TAMS 0x0000000085f00000, 0x0000000085f00000| Untracked 
+|  15|0x0000000085f00000, 0x0000000086000000, 0x0000000086000000|100%| O|  |TAMS 0x0000000086000000, 0x0000000086000000| Untracked 
+|  16|0x0000000086000000, 0x0000000086100000, 0x0000000086100000|100%| O|  |TAMS 0x0000000086100000, 0x0000000086100000| Untracked 
+|  17|0x0000000086100000, 0x0000000086200000, 0x0000000086200000|100%| O|  |TAMS 0x0000000086100000, 0x0000000086200000| Untracked 
+|  18|0x0000000086200000, 0x0000000086300000, 0x0000000086300000|100%| O|  |TAMS 0x0000000086300000, 0x0000000086300000| Untracked 
+|  19|0x0000000086300000, 0x0000000086400000, 0x0000000086400000|100%| O|  |TAMS 0x0000000086400000, 0x0000000086400000| Untracked 
+|  20|0x0000000086400000, 0x0000000086500000, 0x0000000086500000|100%| O|  |TAMS 0x0000000086500000, 0x0000000086500000| Untracked 
+|  21|0x0000000086500000, 0x0000000086600000, 0x0000000086600000|100%| O|  |TAMS 0x0000000086600000, 0x0000000086600000| Untracked 
+|  22|0x0000000086600000, 0x0000000086700000, 0x0000000086700000|100%| O|  |TAMS 0x0000000086700000, 0x0000000086700000| Untracked 
+|  23|0x0000000086700000, 0x0000000086800000, 0x0000000086800000|100%| O|  |TAMS 0x0000000086800000, 0x0000000086800000| Untracked 
+|  24|0x0000000086800000, 0x0000000086900000, 0x0000000086900000|100%| O|  |TAMS 0x0000000086900000, 0x0000000086900000| Untracked 
+|  25|0x0000000086900000, 0x0000000086a00000, 0x0000000086a00000|100%| O|  |TAMS 0x0000000086a00000, 0x0000000086a00000| Untracked 
+|  26|0x0000000086a00000, 0x0000000086b00000, 0x0000000086b00000|100%| O|  |TAMS 0x0000000086b00000, 0x0000000086b00000| Untracked 
+|  27|0x0000000086b00000, 0x0000000086c00000, 0x0000000086c00000|100%| O|  |TAMS 0x0000000086c00000, 0x0000000086c00000| Untracked 
+|  28|0x0000000086c00000, 0x0000000086d00000, 0x0000000086d00000|100%| O|  |TAMS 0x0000000086d00000, 0x0000000086d00000| Untracked 
+|  29|0x0000000086d00000, 0x0000000086e00000, 0x0000000086e00000|100%| O|  |TAMS 0x0000000086e00000, 0x0000000086e00000| Untracked 
+|  30|0x0000000086e00000, 0x0000000086f00000, 0x0000000086f00000|100%| O|  |TAMS 0x0000000086f00000, 0x0000000086f00000| Untracked 
+|  31|0x0000000086f00000, 0x0000000087000000, 0x0000000087000000|100%| O|  |TAMS 0x0000000087000000, 0x0000000087000000| Untracked 
+|  32|0x0000000087000000, 0x0000000087100000, 0x0000000087100000|100%| O|  |TAMS 0x0000000087100000, 0x0000000087100000| Untracked 
+|  33|0x0000000087100000, 0x0000000087200000, 0x0000000087200000|100%| O|  |TAMS 0x0000000087200000, 0x0000000087200000| Untracked 
+|  34|0x0000000087200000, 0x0000000087300000, 0x0000000087300000|100%| O|  |TAMS 0x0000000087300000, 0x0000000087300000| Untracked 
+|  35|0x0000000087300000, 0x0000000087400000, 0x0000000087400000|100%| O|  |TAMS 0x0000000087400000, 0x0000000087400000| Untracked 
+|  36|0x0000000087400000, 0x0000000087500000, 0x0000000087500000|100%| O|  |TAMS 0x00000000874a0c00, 0x0000000087500000| Untracked 
+|  37|0x0000000087500000, 0x0000000087600000, 0x0000000087600000|100%| O|  |TAMS 0x0000000087500000, 0x0000000087600000| Untracked 
+|  38|0x0000000087600000, 0x0000000087700000, 0x0000000087700000|100%| O|  |TAMS 0x0000000087600000, 0x0000000087700000| Untracked 
+|  39|0x0000000087700000, 0x0000000087800000, 0x0000000087800000|100%| O|  |TAMS 0x0000000087700000, 0x0000000087800000| Untracked 
+|  40|0x0000000087800000, 0x0000000087900000, 0x0000000087900000|100%| O|  |TAMS 0x0000000087800000, 0x0000000087900000| Untracked 
+|  41|0x0000000087900000, 0x0000000087a00000, 0x0000000087a00000|100%| O|  |TAMS 0x0000000087900000, 0x0000000087a00000| Untracked 
+|  42|0x0000000087a00000, 0x0000000087b00000, 0x0000000087b00000|100%| O|  |TAMS 0x0000000087a00000, 0x0000000087b00000| Untracked 
+|  43|0x0000000087b00000, 0x0000000087c00000, 0x0000000087c00000|100%| O|  |TAMS 0x0000000087b00000, 0x0000000087c00000| Untracked 
+|  44|0x0000000087c00000, 0x0000000087d00000, 0x0000000087d00000|100%| O|  |TAMS 0x0000000087c00000, 0x0000000087d00000| Untracked 
+|  45|0x0000000087d00000, 0x0000000087e00000, 0x0000000087e00000|100%| O|  |TAMS 0x0000000087d00000, 0x0000000087e00000| Untracked 
+|  46|0x0000000087e00000, 0x0000000087f00000, 0x0000000087f00000|100%| O|  |TAMS 0x0000000087e00000, 0x0000000087e9c400| Untracked 
+|  47|0x0000000087f00000, 0x0000000088000000, 0x0000000088000000|100%| O|  |TAMS 0x0000000087f00000, 0x0000000087f00000| Untracked 
+|  48|0x0000000088000000, 0x0000000088100000, 0x0000000088100000|100%| O|  |TAMS 0x0000000088000000, 0x0000000088000000| Untracked 
+|  49|0x0000000088100000, 0x0000000088200000, 0x0000000088200000|100%| O|  |TAMS 0x0000000088100000, 0x0000000088100000| Untracked 
+|  50|0x0000000088200000, 0x0000000088300000, 0x0000000088300000|100%| O|  |TAMS 0x0000000088200000, 0x0000000088200000| Untracked 
+|  51|0x0000000088300000, 0x0000000088400000, 0x0000000088400000|100%| O|  |TAMS 0x0000000088300000, 0x0000000088300000| Untracked 
+|  52|0x0000000088400000, 0x0000000088400000, 0x0000000088500000|  0%| F|  |TAMS 0x0000000088400000, 0x0000000088400000| Untracked 
+|  53|0x0000000088500000, 0x0000000088500000, 0x0000000088600000|  0%| F|  |TAMS 0x0000000088500000, 0x0000000088500000| Untracked 
+|  54|0x0000000088600000, 0x0000000088600000, 0x0000000088700000|  0%| F|  |TAMS 0x0000000088600000, 0x0000000088600000| Untracked 
+|  55|0x0000000088700000, 0x0000000088700000, 0x0000000088800000|  0%| F|  |TAMS 0x0000000088700000, 0x0000000088700000| Untracked 
+|  56|0x0000000088800000, 0x0000000088800000, 0x0000000088900000|  0%| F|  |TAMS 0x0000000088800000, 0x0000000088800000| Untracked 
+|  57|0x0000000088900000, 0x0000000088900000, 0x0000000088a00000|  0%| F|  |TAMS 0x0000000088900000, 0x0000000088900000| Untracked 
+|  58|0x0000000088a00000, 0x0000000088a00000, 0x0000000088b00000|  0%| F|  |TAMS 0x0000000088a00000, 0x0000000088a00000| Untracked 
+|  59|0x0000000088b00000, 0x0000000088b00000, 0x0000000088c00000|  0%| F|  |TAMS 0x0000000088b00000, 0x0000000088b00000| Untracked 
+|  60|0x0000000088c00000, 0x0000000088c00000, 0x0000000088d00000|  0%| F|  |TAMS 0x0000000088c00000, 0x0000000088c00000| Untracked 
+|  61|0x0000000088d00000, 0x0000000088d00000, 0x0000000088e00000|  0%| F|  |TAMS 0x0000000088d00000, 0x0000000088d00000| Untracked 
+|  62|0x0000000088e00000, 0x0000000088e00000, 0x0000000088f00000|  0%| F|  |TAMS 0x0000000088e00000, 0x0000000088e00000| Untracked 
+|  63|0x0000000088f00000, 0x0000000088f00000, 0x0000000089000000|  0%| F|  |TAMS 0x0000000088f00000, 0x0000000088f00000| Untracked 
+|  64|0x0000000089000000, 0x0000000089100000, 0x0000000089100000|100%| S|CS|TAMS 0x0000000089000000, 0x0000000089000000| Complete 
+|  65|0x0000000089100000, 0x0000000089200000, 0x0000000089200000|100%| S|CS|TAMS 0x0000000089100000, 0x0000000089100000| Complete 
+|  66|0x0000000089200000, 0x0000000089200000, 0x0000000089300000|  0%| F|  |TAMS 0x0000000089200000, 0x0000000089200000| Untracked 
+|  67|0x0000000089300000, 0x0000000089300000, 0x0000000089400000|  0%| F|  |TAMS 0x0000000089300000, 0x0000000089300000| Untracked 
+|  68|0x0000000089400000, 0x0000000089400000, 0x0000000089500000|  0%| F|  |TAMS 0x0000000089400000, 0x0000000089400000| Untracked 
+|  69|0x0000000089500000, 0x0000000089600000, 0x0000000089600000|100%| S|CS|TAMS 0x0000000089500000, 0x0000000089500000| Complete 
+|  70|0x0000000089600000, 0x0000000089600000, 0x0000000089700000|  0%| F|  |TAMS 0x0000000089600000, 0x0000000089600000| Untracked 
+|  71|0x0000000089700000, 0x0000000089700000, 0x0000000089800000|  0%| F|  |TAMS 0x0000000089700000, 0x0000000089700000| Untracked 
+|  72|0x0000000089800000, 0x0000000089800000, 0x0000000089900000|  0%| F|  |TAMS 0x0000000089800000, 0x0000000089800000| Untracked 
+|  73|0x0000000089900000, 0x0000000089900000, 0x0000000089a00000|  0%| F|  |TAMS 0x0000000089900000, 0x0000000089900000| Untracked 
+|  74|0x0000000089a00000, 0x0000000089a00000, 0x0000000089b00000|  0%| F|  |TAMS 0x0000000089a00000, 0x0000000089a00000| Untracked 
+|  75|0x0000000089b00000, 0x0000000089b00000, 0x0000000089c00000|  0%| F|  |TAMS 0x0000000089b00000, 0x0000000089b00000| Untracked 
+|  76|0x0000000089c00000, 0x0000000089c00000, 0x0000000089d00000|  0%| F|  |TAMS 0x0000000089c00000, 0x0000000089c00000| Untracked 
+|  77|0x0000000089d00000, 0x0000000089d00000, 0x0000000089e00000|  0%| F|  |TAMS 0x0000000089d00000, 0x0000000089d00000| Untracked 
+|  78|0x0000000089e00000, 0x0000000089e00000, 0x0000000089f00000|  0%| F|  |TAMS 0x0000000089e00000, 0x0000000089e00000| Untracked 
+|  79|0x0000000089f00000, 0x0000000089f00000, 0x000000008a000000|  0%| F|  |TAMS 0x0000000089f00000, 0x0000000089f00000| Untracked 
+|  80|0x000000008a000000, 0x000000008a000000, 0x000000008a100000|  0%| F|  |TAMS 0x000000008a000000, 0x000000008a000000| Untracked 
+|  81|0x000000008a100000, 0x000000008a100000, 0x000000008a200000|  0%| F|  |TAMS 0x000000008a100000, 0x000000008a100000| Untracked 
+|  82|0x000000008a200000, 0x000000008a200000, 0x000000008a300000|  0%| F|  |TAMS 0x000000008a200000, 0x000000008a200000| Untracked 
+|  83|0x000000008a300000, 0x000000008a300000, 0x000000008a400000|  0%| F|  |TAMS 0x000000008a300000, 0x000000008a300000| Untracked 
+|  84|0x000000008a400000, 0x000000008a400000, 0x000000008a500000|  0%| F|  |TAMS 0x000000008a400000, 0x000000008a400000| Untracked 
+|  85|0x000000008a500000, 0x000000008a500000, 0x000000008a600000|  0%| F|  |TAMS 0x000000008a500000, 0x000000008a500000| Untracked 
+|  86|0x000000008a600000, 0x000000008a600000, 0x000000008a700000|  0%| F|  |TAMS 0x000000008a600000, 0x000000008a600000| Untracked 
+|  87|0x000000008a700000, 0x000000008a700000, 0x000000008a800000|  0%| F|  |TAMS 0x000000008a700000, 0x000000008a700000| Untracked 
+|  88|0x000000008a800000, 0x000000008a800000, 0x000000008a900000|  0%| F|  |TAMS 0x000000008a800000, 0x000000008a800000| Untracked 
+|  89|0x000000008a900000, 0x000000008a900000, 0x000000008aa00000|  0%| F|  |TAMS 0x000000008a900000, 0x000000008a900000| Untracked 
+|  90|0x000000008aa00000, 0x000000008aa00000, 0x000000008ab00000|  0%| F|  |TAMS 0x000000008aa00000, 0x000000008aa00000| Untracked 
+|  91|0x000000008ab00000, 0x000000008ab00000, 0x000000008ac00000|  0%| F|  |TAMS 0x000000008ab00000, 0x000000008ab00000| Untracked 
+|  92|0x000000008ac00000, 0x000000008ac00000, 0x000000008ad00000|  0%| F|  |TAMS 0x000000008ac00000, 0x000000008ac00000| Untracked 
+|  93|0x000000008ad00000, 0x000000008ad00000, 0x000000008ae00000|  0%| F|  |TAMS 0x000000008ad00000, 0x000000008ad00000| Untracked 
+|  94|0x000000008ae00000, 0x000000008ae00000, 0x000000008af00000|  0%| F|  |TAMS 0x000000008ae00000, 0x000000008ae00000| Untracked 
+|  95|0x000000008af00000, 0x000000008af00000, 0x000000008b000000|  0%| F|  |TAMS 0x000000008af00000, 0x000000008af00000| Untracked 
+|  96|0x000000008b000000, 0x000000008b000000, 0x000000008b100000|  0%| F|  |TAMS 0x000000008b000000, 0x000000008b000000| Untracked 
+|  97|0x000000008b100000, 0x000000008b100000, 0x000000008b200000|  0%| F|  |TAMS 0x000000008b100000, 0x000000008b100000| Untracked 
+|  98|0x000000008b200000, 0x000000008b200000, 0x000000008b300000|  0%| F|  |TAMS 0x000000008b200000, 0x000000008b200000| Untracked 
+|  99|0x000000008b300000, 0x000000008b300000, 0x000000008b400000|  0%| F|  |TAMS 0x000000008b300000, 0x000000008b300000| Untracked 
+| 100|0x000000008b400000, 0x000000008b400000, 0x000000008b500000|  0%| F|  |TAMS 0x000000008b400000, 0x000000008b400000| Untracked 
+| 101|0x000000008b500000, 0x000000008b500000, 0x000000008b600000|  0%| F|  |TAMS 0x000000008b500000, 0x000000008b500000| Untracked 
+| 102|0x000000008b600000, 0x000000008b600000, 0x000000008b700000|  0%| F|  |TAMS 0x000000008b600000, 0x000000008b600000| Untracked 
+| 103|0x000000008b700000, 0x000000008b700000, 0x000000008b800000|  0%| F|  |TAMS 0x000000008b700000, 0x000000008b700000| Untracked 
+| 104|0x000000008b800000, 0x000000008b800000, 0x000000008b900000|  0%| F|  |TAMS 0x000000008b800000, 0x000000008b800000| Untracked 
+| 105|0x000000008b900000, 0x000000008b900000, 0x000000008ba00000|  0%| F|  |TAMS 0x000000008b900000, 0x000000008b900000| Untracked 
+| 106|0x000000008ba00000, 0x000000008ba00000, 0x000000008bb00000|  0%| F|  |TAMS 0x000000008ba00000, 0x000000008ba00000| Untracked 
+| 107|0x000000008bb00000, 0x000000008bb00000, 0x000000008bc00000|  0%| F|  |TAMS 0x000000008bb00000, 0x000000008bb00000| Untracked 
+| 108|0x000000008bc00000, 0x000000008bc00000, 0x000000008bd00000|  0%| F|  |TAMS 0x000000008bc00000, 0x000000008bc00000| Untracked 
+| 109|0x000000008bd00000, 0x000000008bd00000, 0x000000008be00000|  0%| F|  |TAMS 0x000000008bd00000, 0x000000008bd00000| Untracked 
+| 110|0x000000008be00000, 0x000000008be00000, 0x000000008bf00000|  0%| F|  |TAMS 0x000000008be00000, 0x000000008be00000| Untracked 
+| 111|0x000000008bf00000, 0x000000008bf00000, 0x000000008c000000|  0%| F|  |TAMS 0x000000008bf00000, 0x000000008bf00000| Untracked 
+| 112|0x000000008c000000, 0x000000008c000000, 0x000000008c100000|  0%| F|  |TAMS 0x000000008c000000, 0x000000008c000000| Untracked 
+| 113|0x000000008c100000, 0x000000008c100000, 0x000000008c200000|  0%| F|  |TAMS 0x000000008c100000, 0x000000008c100000| Untracked 
+| 114|0x000000008c200000, 0x000000008c200000, 0x000000008c300000|  0%| F|  |TAMS 0x000000008c200000, 0x000000008c200000| Untracked 
+| 115|0x000000008c300000, 0x000000008c300000, 0x000000008c400000|  0%| F|  |TAMS 0x000000008c300000, 0x000000008c300000| Untracked 
+| 116|0x000000008c400000, 0x000000008c400000, 0x000000008c500000|  0%| F|  |TAMS 0x000000008c400000, 0x000000008c400000| Untracked 
+| 117|0x000000008c500000, 0x000000008c500000, 0x000000008c600000|  0%| F|  |TAMS 0x000000008c500000, 0x000000008c500000| Untracked 
+| 118|0x000000008c600000, 0x000000008c600000, 0x000000008c700000|  0%| F|  |TAMS 0x000000008c600000, 0x000000008c600000| Untracked 
+| 119|0x000000008c700000, 0x000000008c700000, 0x000000008c800000|  0%| F|  |TAMS 0x000000008c700000, 0x000000008c700000| Untracked 
+| 120|0x000000008c800000, 0x000000008c800000, 0x000000008c900000|  0%| F|  |TAMS 0x000000008c800000, 0x000000008c800000| Untracked 
+| 121|0x000000008c900000, 0x000000008c900000, 0x000000008ca00000|  0%| F|  |TAMS 0x000000008c900000, 0x000000008c900000| Untracked 
+| 122|0x000000008ca00000, 0x000000008ca00000, 0x000000008cb00000|  0%| F|  |TAMS 0x000000008ca00000, 0x000000008ca00000| Untracked 
+| 123|0x000000008cb00000, 0x000000008cb00000, 0x000000008cc00000|  0%| F|  |TAMS 0x000000008cb00000, 0x000000008cb00000| Untracked 
+
+Card table byte_map: [0x0000019a22800000,0x0000019a22be0000] _byte_map_base: 0x0000019a223d8000
+
+Marking Bits (Prev, Next): (CMBitMap*) 0x0000019a15afd140, (CMBitMap*) 0x0000019a15afd100
+ Prev Bits: [0x0000019a24e80000, 0x0000019a26d40000)
+ Next Bits: [0x0000019a22fc0000, 0x0000019a24e80000)
+
+Polling page: 0x0000019a15b50000
+
+Metaspace:
+
+Usage:
+  Non-class:     62.04 MB used.
+      Class:     10.85 MB used.
+       Both:     72.89 MB used.
+
+Virtual space:
+  Non-class space:       64.00 MB reserved,      62.38 MB ( 97%) committed,  1 nodes.
+      Class space:        1.00 GB reserved,      11.12 MB (  1%) committed,  1 nodes.
+             Both:        1.06 GB reserved,      73.50 MB (  7%) committed. 
+
+Chunk freelists:
+   Non-Class:  1.57 MB
+       Class:  4.72 MB
+        Both:  6.29 MB
+
+MaxMetaspaceSize: unlimited
+CompressedClassSpaceSize: 1.00 GB
+Initial GC threshold: 21.00 MB
+Current GC threshold: 122.50 MB
+CDS: on
+MetaspaceReclaimPolicy: balanced
+ - commit_granule_bytes: 65536.
+ - commit_granule_words: 8192.
+ - virtual_space_node_default_size: 8388608.
+ - enlarge_chunks_in_place: 1.
+ - new_chunks_are_fully_committed: 0.
+ - uncommit_free_chunks: 1.
+ - use_allocation_guard: 0.
+ - handle_deallocations: 1.
+
+
+Internal statistics:
+
+num_allocs_failed_limit: 6.
+num_arena_births: 938.
+num_arena_deaths: 54.
+num_vsnodes_births: 2.
+num_vsnodes_deaths: 0.
+num_space_committed: 1176.
+num_space_uncommitted: 0.
+num_chunks_returned_to_freelist: 67.
+num_chunks_taken_from_freelist: 3767.
+num_chunk_merges: 16.
+num_chunk_splits: 2733.
+num_chunks_enlarged: 2158.
+num_inconsistent_stats: 0.
+
+CodeCache: size=49152Kb used=13631Kb max_used=13631Kb free=35520Kb
+ bounds [0x0000019a1eb40000, 0x0000019a1f890000, 0x0000019a21b40000]
+ total_blobs=8064 nmethods=7381 adapters=607
+ compilation: enabled
+              stopped_count=0, restarted_count=0
+ full_count=0
+
+Compilation events (20 events):
+Event: 60.028 Thread 0x0000019a716de800 7372       1       org.springframework.data.repository.core.support.DefaultRepositoryMetadata::getDomainTypeInformation (5 bytes)
+Event: 60.028 Thread 0x0000019a716de800 nmethod 7372 0x0000019a1f88d010 code [0x0000019a1f88d1a0, 0x0000019a1f88d278]
+Event: 60.032 Thread 0x0000019a29803680 7373       1       org.hibernate.metamodel.internal.RuntimeMetamodelsImpl::getJpaMetamodel (5 bytes)
+Event: 60.032 Thread 0x0000019a29803680 nmethod 7373 0x0000019a1f88d310 code [0x0000019a1f88d4a0, 0x0000019a1f88d578]
+Event: 60.035 Thread 0x0000019a716de800 7374       1       org.springframework.data.repository.util.QueryExecutionConverters$WrapperType::getType (5 bytes)
+Event: 60.035 Thread 0x0000019a716de800 nmethod 7374 0x0000019a1f88d610 code [0x0000019a1f88d7a0, 0x0000019a1f88d878]
+Event: 60.048 Thread 0x0000019a716de800 7375   !   1       org.antlr.v4.runtime.atn.LexerATNSimulator::addDFAState (224 bytes)
+Event: 60.048 Thread 0x0000019a70d661e0 7376       1       org.antlr.v4.runtime.atn.LexerATNSimulator::addDFAEdge (37 bytes)
+Event: 60.049 Thread 0x0000019a70d661e0 nmethod 7376 0x0000019a1f88d910 code [0x0000019a1f88dac0, 0x0000019a1f88dc38]
+Event: 60.050 Thread 0x0000019a716de800 nmethod 7375 0x0000019a1f88dd10 code [0x0000019a1f88df40, 0x0000019a1f88e7e8]
+Event: 60.051 Thread 0x0000019a29803680 7377       1       org.hibernate.jpa.internal.JpaComplianceImpl::isJpaQueryComplianceEnabled (5 bytes)
+Event: 60.051 Thread 0x0000019a29803680 nmethod 7377 0x0000019a1f88ed10 code [0x0000019a1f88eea0, 0x0000019a1f88ef78]
+Event: 60.055 Thread 0x0000019a29803680 7378       1       org.antlr.v4.runtime.misc.IntegerStack::push (6 bytes)
+Event: 60.055 Thread 0x0000019a70d661e0 7379       1       org.antlr.v4.runtime.misc.IntegerList::add (43 bytes)
+Event: 60.055 Thread 0x0000019a716de800 7380       1       org.hibernate.boot.internal.SessionFactoryOptionsBuilder::getJpaCompliance (5 bytes)
+Event: 60.056 Thread 0x0000019a29803680 nmethod 7378 0x0000019a1f88f010 code [0x0000019a1f88f1a0, 0x0000019a1f88f288]
+Event: 60.056 Thread 0x0000019a70d661e0 nmethod 7379 0x0000019a1f88f310 code [0x0000019a1f88f4a0, 0x0000019a1f88f5e8]
+Event: 60.056 Thread 0x0000019a716de800 nmethod 7380 0x0000019a1f88f710 code [0x0000019a1f88f8a0, 0x0000019a1f88f978]
+Event: 60.059 Thread 0x0000019a70d661e0 7381       1       org.springframework.util.Assert::isInstanceOf (21 bytes)
+Event: 60.059 Thread 0x0000019a70d661e0 nmethod 7381 0x0000019a1f88fa10 code [0x0000019a1f88fbc0, 0x0000019a1f88fd58]
+
+GC Heap History (20 events):
+Event: 56.816 GC heap after
+{Heap after GC invocations=25 (full 0):
+ garbage-first heap   total 61440K, used 36130K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 2 young (2048K), 2 survivors (2048K)
+ Metaspace       used 66620K, committed 67264K, reserved 1114112K
+  class space    used 9863K, committed 10176K, reserved 1048576K
+}
+Event: 57.380 GC heap before
+{Heap before GC invocations=25 (full 0):
+ garbage-first heap   total 61440K, used 50466K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 17 young (17408K), 2 survivors (2048K)
+ Metaspace       used 68249K, committed 68864K, reserved 1114112K
+  class space    used 10216K, committed 10496K, reserved 1048576K
+}
+Event: 57.385 GC heap after
+{Heap after GC invocations=26 (full 0):
+ garbage-first heap   total 61440K, used 36566K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 2 young (2048K), 2 survivors (2048K)
+ Metaspace       used 68249K, committed 68864K, reserved 1114112K
+  class space    used 10216K, committed 10496K, reserved 1048576K
+}
+Event: 57.565 GC heap before
+{Heap before GC invocations=27 (full 0):
+ garbage-first heap   total 63488K, used 51926K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 17 young (17408K), 2 survivors (2048K)
+ Metaspace       used 68402K, committed 68992K, reserved 1114112K
+  class space    used 10246K, committed 10560K, reserved 1048576K
+}
+Event: 57.569 GC heap after
+{Heap after GC invocations=28 (full 0):
+ garbage-first heap   total 63488K, used 37201K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 2 young (2048K), 2 survivors (2048K)
+ Metaspace       used 68402K, committed 68992K, reserved 1114112K
+  class space    used 10246K, committed 10560K, reserved 1048576K
+}
+Event: 57.576 GC heap before
+{Heap before GC invocations=28 (full 0):
+ garbage-first heap   total 63488K, used 38225K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 3 young (3072K), 2 survivors (2048K)
+ Metaspace       used 68402K, committed 68992K, reserved 1114112K
+  class space    used 10246K, committed 10560K, reserved 1048576K
+}
+Event: 57.579 GC heap after
+{Heap after GC invocations=29 (full 0):
+ garbage-first heap   total 63488K, used 36616K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 1 young (1024K), 1 survivors (1024K)
+ Metaspace       used 68402K, committed 68992K, reserved 1114112K
+  class space    used 10246K, committed 10560K, reserved 1048576K
+}
+Event: 58.104 GC heap before
+{Heap before GC invocations=29 (full 0):
+ garbage-first heap   total 63488K, used 50952K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 16 young (16384K), 1 survivors (1024K)
+ Metaspace       used 70324K, committed 70912K, reserved 1114112K
+  class space    used 10539K, committed 10816K, reserved 1048576K
+}
+Event: 58.111 GC heap after
+{Heap after GC invocations=30 (full 0):
+ garbage-first heap   total 63488K, used 37421K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 1 young (1024K), 1 survivors (1024K)
+ Metaspace       used 70324K, committed 70912K, reserved 1114112K
+  class space    used 10539K, committed 10816K, reserved 1048576K
+}
+Event: 58.313 GC heap before
+{Heap before GC invocations=31 (full 0):
+ garbage-first heap   total 76800K, used 51757K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 15 young (15360K), 1 survivors (1024K)
+ Metaspace       used 70327K, committed 70912K, reserved 1114112K
+  class space    used 10540K, committed 10816K, reserved 1048576K
+}
+Event: 58.318 GC heap after
+{Heap after GC invocations=32 (full 0):
+ garbage-first heap   total 76800K, used 37877K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 2 young (2048K), 2 survivors (2048K)
+ Metaspace       used 70327K, committed 70912K, reserved 1114112K
+  class space    used 10540K, committed 10816K, reserved 1048576K
+}
+Event: 58.772 GC heap before
+{Heap before GC invocations=32 (full 0):
+ garbage-first heap   total 76800K, used 61429K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 25 young (25600K), 2 survivors (2048K)
+ Metaspace       used 70974K, committed 71552K, reserved 1114112K
+  class space    used 10646K, committed 10944K, reserved 1048576K
+}
+Event: 58.778 GC heap after
+{Heap after GC invocations=33 (full 0):
+ garbage-first heap   total 76800K, used 38026K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 2 young (2048K), 2 survivors (2048K)
+ Metaspace       used 70974K, committed 71552K, reserved 1114112K
+  class space    used 10646K, committed 10944K, reserved 1048576K
+}
+Event: 59.951 GC heap before
+{Heap before GC invocations=34 (full 0):
+ garbage-first heap   total 76800K, used 61578K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 26 young (26624K), 2 survivors (2048K)
+ Metaspace       used 74581K, committed 75264K, reserved 1114112K
+  class space    used 11101K, committed 11392K, reserved 1048576K
+}
+Event: 59.960 GC heap after
+{Heap after GC invocations=35 (full 0):
+ garbage-first heap   total 76800K, used 40306K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 4 young (4096K), 4 survivors (4096K)
+ Metaspace       used 74581K, committed 75264K, reserved 1114112K
+  class space    used 11101K, committed 11392K, reserved 1048576K
+}
+Event: 60.181 GC heap before
+{Heap before GC invocations=35 (full 0):
+ garbage-first heap   total 76800K, used 61810K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 25 young (25600K), 4 survivors (4096K)
+ Metaspace       used 74640K, committed 75264K, reserved 1114112K
+  class space    used 11113K, committed 11392K, reserved 1048576K
+}
+Event: 60.195 GC heap after
+{Heap after GC invocations=36 (full 0):
+ garbage-first heap   total 76800K, used 44810K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 4 young (4096K), 4 survivors (4096K)
+ Metaspace       used 74640K, committed 75264K, reserved 1114112K
+  class space    used 11113K, committed 11392K, reserved 1048576K
+}
+Event: 60.377 GC heap before
+{Heap before GC invocations=37 (full 0):
+ garbage-first heap   total 86016K, used 59146K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 19 young (19456K), 4 survivors (4096K)
+ Metaspace       used 74640K, committed 75264K, reserved 1114112K
+  class space    used 11113K, committed 11392K, reserved 1048576K
+}
+Event: 60.392 GC heap after
+{Heap after GC invocations=38 (full 0):
+ garbage-first heap   total 86016K, used 50801K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 3 young (3072K), 3 survivors (3072K)
+ Metaspace       used 74640K, committed 75264K, reserved 1114112K
+  class space    used 11113K, committed 11392K, reserved 1048576K
+}
+Event: 60.490 GC heap before
+{Heap before GC invocations=38 (full 0):
+ garbage-first heap   total 86016K, used 65137K [0x0000000085000000, 0x0000000100000000)
+  region size 1024K, 17 young (17408K), 3 survivors (3072K)
+ Metaspace       used 74640K, committed 75264K, reserved 1114112K
+  class space    used 11113K, committed 11392K, reserved 1048576K
+}
+
+Deoptimization events (4 events):
+Event: 41.829 Thread 0x0000019a15aa28c0 DEOPT PACKING pc=0x0000019a1eff0b81 sp=0x0000000d722fea70
+Event: 41.829 Thread 0x0000019a15aa28c0 DEOPT UNPACKING pc=0x0000019a1eb966e3 sp=0x0000000d722fdf00 mode 3
+Event: 41.830 Thread 0x0000019a6f3e87c0 DEOPT PACKING pc=0x0000019a1ef60697 sp=0x0000000d745feef0
+Event: 41.830 Thread 0x0000019a6f3e87c0 DEOPT UNPACKING pc=0x0000019a1eb966e3 sp=0x0000000d745fe348 mode 3
+
+Classes unloaded (20 events):
+Event: 40.175 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b0c0800 'jdk/internal/reflect/GeneratedSerializationConstructorAccessor3'
+Event: 40.175 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b009000 'java/lang/invoke/LambdaForm$DMH+0x0000019a2b009000'
+Event: 40.175 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b008800 'java/lang/invoke/LambdaForm$DMH+0x0000019a2b008800'
+Event: 40.175 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b007c00 'jdk/internal/reflect/GeneratedConstructorAccessor1'
+Event: 48.936 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b176000 'java/lang/invoke/LambdaForm$DMH+0x0000019a2b176000'
+Event: 48.936 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b175800 'java/lang/invoke/LambdaForm$DMH+0x0000019a2b175800'
+Event: 48.936 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b175000 'java/lang/invoke/LambdaForm$DMH+0x0000019a2b175000'
+Event: 48.936 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b170400 'java/lang/invoke/LambdaForm$DMH+0x0000019a2b170400'
+Event: 48.936 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b12c000 'java/lang/invoke/LambdaForm$DMH+0x0000019a2b12c000'
+Event: 51.005 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b28d400 'java/lang/invoke/LambdaForm$MH+0x0000019a2b28d400'
+Event: 51.005 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b28d000 'java/lang/invoke/LambdaForm$MH+0x0000019a2b28d000'
+Event: 51.005 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b28cc00 'java/lang/invoke/LambdaForm$MH+0x0000019a2b28cc00'
+Event: 51.005 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b28c800 'java/lang/invoke/LambdaForm$MH+0x0000019a2b28c800'
+Event: 51.005 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b28c400 'java/lang/invoke/LambdaForm$MH+0x0000019a2b28c400'
+Event: 51.005 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b1b8c00 'java/lang/invoke/LambdaForm$MH+0x0000019a2b1b8c00'
+Event: 51.005 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b1b5400 'java/lang/invoke/LambdaForm$MH+0x0000019a2b1b5400'
+Event: 51.005 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b1b5000 'java/lang/invoke/LambdaForm$MH+0x0000019a2b1b5000'
+Event: 51.005 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b0d4000 'java/lang/invoke/LambdaForm$MH+0x0000019a2b0d4000'
+Event: 55.653 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b395800 'jdk/internal/reflect/GeneratedConstructorAccessor14'
+Event: 55.653 Thread 0x0000019a297e15b0 Unloading class 0x0000019a2b334400 'java/lang/invoke/LambdaForm$DMH+0x0000019a2b334400'
+
+Classes redefined (0 events):
+No events
+
+Internal exceptions (20 events):
+Event: 58.524 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/NoSuchMethodError'{0x00000000888af9c0}: 'int java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.lang.Object, java.lang.Object, int)'> (0x00000000888af9c0) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 759]
+Event: 58.545 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/IncompatibleClassChangeError'{0x00000000888f8940}: Found class java.lang.Object, but interface was expected> (0x00000000888f8940) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 826]
+Event: 58.574 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/NoSuchMethodError'{0x00000000887873f0}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.lang.Object, int, java.lang.Object)'> (0x00000000887873f0) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 759]
+Event: 58.579 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x00000000887adef8}> (0x00000000887adef8) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+Event: 58.582 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x00000000887bad18}> (0x00000000887bad18) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+Event: 58.585 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x00000000887c5978}> (0x00000000887c5978) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+Event: 58.620 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/NoSuchMethodError'{0x000000008869deb8}: 'int java.lang.invoke.DirectMethodHandle$Holder.invokeStaticInit(java.lang.Object, int, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x000000008869deb8) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 759]
+Event: 58.715 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x00000000884ec1e8}> (0x00000000884ec1e8) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+Event: 58.718 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x00000000884fa6d0}> (0x00000000884fa6d0) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+Event: 58.722 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x00000000883094d0}> (0x00000000883094d0) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+Event: 58.733 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x000000008832d570}> (0x000000008832d570) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+Event: 58.757 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x000000008826b3b8}> (0x000000008826b3b8) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+Event: 58.764 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x00000000882882f0}> (0x00000000882882f0) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+Event: 59.129 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/NoSuchMethodError'{0x000000008be163c8}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeStaticInit(java.lang.Object, java.lang.Object, int)'> (0x000000008be163c8) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 759]
+Event: 59.320 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/NoSuchMethodError'{0x000000008bcdb7d0}: 'void java.lang.invoke.DirectMethodHandle$Holder.invokeStaticInit(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x000000008bcdb7d0) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 759]
+Event: 59.645 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/NoSuchMethodError'{0x0000000088ebd878}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeStaticInit(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x0000000088ebd878) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 759]
+Event: 59.859 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x0000000088a55dc8}> (0x0000000088a55dc8) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+Event: 59.877 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x0000000088a72f40}> (0x0000000088a72f40) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+Event: 59.897 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x00000000889ac948}> (0x00000000889ac948) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+Event: 59.910 Thread 0x0000019a15aa28c0 Exception <a 'java/lang/reflect/InvocationTargetException'{0x00000000889ffd40}> (0x00000000889ffd40) 
+thrown [s\open\src\hotspot\share\runtime\reflection.cpp, line 1121]
+
+VM Operations (20 events):
+Event: 58.778 Executing VM operation: G1CollectForAllocation done
+Event: 58.843 Executing VM operation: G1Concurrent
+Event: 58.848 Executing VM operation: G1Concurrent done
+Event: 58.874 Executing VM operation: G1Concurrent
+Event: 58.875 Executing VM operation: G1Concurrent done
+Event: 59.408 Executing VM operation: HandshakeAllThreads
+Event: 59.408 Executing VM operation: HandshakeAllThreads done
+Event: 59.787 Executing VM operation: HandshakeAllThreads
+Event: 59.787 Executing VM operation: HandshakeAllThreads done
+Event: 59.951 Executing VM operation: G1CollectForAllocation
+Event: 59.960 Executing VM operation: G1CollectForAllocation done
+Event: 60.181 Executing VM operation: G1CollectForAllocation
+Event: 60.195 Executing VM operation: G1CollectForAllocation done
+Event: 60.264 Executing VM operation: G1Concurrent
+Event: 60.287 Executing VM operation: G1Concurrent done
+Event: 60.321 Executing VM operation: G1Concurrent
+Event: 60.322 Executing VM operation: G1Concurrent done
+Event: 60.376 Executing VM operation: G1CollectForAllocation
+Event: 60.392 Executing VM operation: G1CollectForAllocation done
+Event: 60.490 Executing VM operation: G1CollectForAllocation
+
+Events (20 events):
+Event: 59.655 loading class com/sun/org/apache/xerces/internal/utils/XMLSecurityPropertyManager$State
+Event: 59.655 loading class com/sun/org/apache/xerces/internal/utils/XMLSecurityPropertyManager$State done
+Event: 59.655 loading class com/sun/org/apache/xerces/internal/utils/XMLSecurityPropertyManager$Property
+Event: 59.655 loading class com/sun/org/apache/xerces/internal/utils/XMLSecurityPropertyManager$Property done
+Event: 59.655 loading class jdk/xml/internal/JdkXmlUtils
+Event: 59.656 loading class jdk/xml/internal/JdkXmlUtils done
+Event: 59.656 loading class javax/xml/catalog/CatalogFeatures$Feature
+Event: 59.657 loading class javax/xml/catalog/CatalogFeatures$Feature done
+Event: 59.657 loading class com/sun/org/apache/xerces/internal/jaxp/SAXParserFactoryImpl
+Event: 59.658 loading class javax/xml/parsers/SAXParserFactory
+Event: 59.659 loading class javax/xml/parsers/SAXParserFactory done
+Event: 59.659 loading class com/sun/org/apache/xerces/internal/jaxp/SAXParserFactoryImpl done
+Event: 59.659 loading class com/sun/xml/internal/stream/StaxEntityResolverWrapper
+Event: 59.660 loading class com/sun/xml/internal/stream/StaxEntityResolverWrapper done
+Event: 59.690 loading class java/nio/charset/CoderMalfunctionError
+Event: 59.690 loading class java/nio/charset/CoderMalfunctionError done
+Event: 59.800 loading class sun/reflect/annotation/AnnotationInvocationHandler$1
+Event: 59.801 loading class sun/reflect/annotation/AnnotationInvocationHandler$1 done
+Event: 60.006 Thread 0x0000019a6f3e6e70 Thread added: 0x0000019a6f3e6e70
+Event: 60.015 Thread 0x0000019a6f3e6e70 Thread exited: 0x0000019a6f3e6e70
+
+
+Dynamic libraries:
+0x00007ff711340000 - 0x00007ff711350000 	C:\Program Files\Java\jdk-17\bin\java.exe
+0x00007ffa71380000 - 0x00007ffa715e8000 	C:\WINDOWS\SYSTEM32\ntdll.dll
+0x00007ffa70290000 - 0x00007ffa70359000 	C:\WINDOWS\System32\KERNEL32.DLL
+0x00007ffa6dfb0000 - 0x00007ffa6e3a1000 	C:\WINDOWS\System32\KERNELBASE.dll
+0x00007ffa6dcf0000 - 0x00007ffa6de3b000 	C:\WINDOWS\System32\ucrtbase.dll
+0x00007ffa5d530000 - 0x00007ffa5d549000 	C:\Program Files\Java\jdk-17\bin\jli.dll
+0x00007ffa70970000 - 0x00007ffa70a24000 	C:\WINDOWS\System32\ADVAPI32.dll
+0x00007ffa6f120000 - 0x00007ffa6f1c9000 	C:\WINDOWS\System32\msvcrt.dll
+0x00007ffa70a30000 - 0x00007ffa70ad6000 	C:\WINDOWS\System32\sechost.dll
+0x00007ffa6f580000 - 0x00007ffa6f698000 	C:\WINDOWS\System32\RPCRT4.dll
+0x00007ffa666f0000 - 0x00007ffa6670b000 	C:\Program Files\Java\jdk-17\bin\VCRUNTIME140.dll
+0x00007ffa70760000 - 0x00007ffa70926000 	C:\WINDOWS\System32\USER32.dll
+0x00007ffa6f0f0000 - 0x00007ffa6f117000 	C:\WINDOWS\System32\win32u.dll
+0x00007ffa6f6f0000 - 0x00007ffa6f71b000 	C:\WINDOWS\System32\GDI32.dll
+0x00007ffa6efc0000 - 0x00007ffa6f0eb000 	C:\WINDOWS\System32\gdi32full.dll
+0x00007ffa6e470000 - 0x00007ffa6e513000 	C:\WINDOWS\System32\msvcp_win.dll
+0x00007ffa54650000 - 0x00007ffa548e3000 	C:\WINDOWS\WinSxS\amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.26100.7824_none_3e0870b2e3345462\COMCTL32.dll
+0x00007ffa5aa50000 - 0x00007ffa5aa5b000 	C:\WINDOWS\SYSTEM32\VERSION.dll
+0x00007ffa70930000 - 0x00007ffa70961000 	C:\WINDOWS\System32\IMM32.DLL
+0x00007ffa693d0000 - 0x00007ffa693dc000 	C:\Program Files\Java\jdk-17\bin\vcruntime140_1.dll
+0x00007ffa15b30000 - 0x00007ffa15bbe000 	C:\Program Files\Java\jdk-17\bin\msvcp140.dll
+0x00007ff9af9f0000 - 0x00007ff9b05d0000 	C:\Program Files\Java\jdk-17\bin\server\jvm.dll
+0x00007ffa71330000 - 0x00007ffa71338000 	C:\WINDOWS\System32\PSAPI.DLL
+0x00007ffa63760000 - 0x00007ffa63795000 	C:\WINDOWS\SYSTEM32\WINMM.dll
+0x00007ffa3df40000 - 0x00007ffa3df4a000 	C:\WINDOWS\SYSTEM32\WSOCK32.dll
+0x00007ffa6ff90000 - 0x00007ffa70004000 	C:\WINDOWS\System32\WS2_32.dll
+0x00007ffa6ca00000 - 0x00007ffa6ca1b000 	C:\WINDOWS\SYSTEM32\kernel.appcore.dll
+0x00007ffa5d580000 - 0x00007ffa5d58a000 	C:\Program Files\Java\jdk-17\bin\jimage.dll
+0x00007ffa6bbf0000 - 0x00007ffa6be32000 	C:\WINDOWS\SYSTEM32\DBGHELP.DLL
+0x00007ffa70ae0000 - 0x00007ffa70e66000 	C:\WINDOWS\System32\combase.dll
+0x00007ffa701b0000 - 0x00007ffa70287000 	C:\WINDOWS\System32\OLEAUT32.dll
+0x00007ffa3a660000 - 0x00007ffa3a69b000 	C:\WINDOWS\SYSTEM32\dbgcore.DLL
+0x00007ffa6e520000 - 0x00007ffa6e5c5000 	C:\WINDOWS\System32\bcryptPrimitives.dll
+0x00007ffa4d820000 - 0x00007ffa4d82e000 	C:\Program Files\Java\jdk-17\bin\instrument.dll
+0x00007ffa3b990000 - 0x00007ffa3b9b5000 	C:\Program Files\Java\jdk-17\bin\java.dll
+0x00007ffa14130000 - 0x00007ffa14207000 	C:\Program Files\Java\jdk-17\bin\jsvml.dll
+0x00007ffa6f830000 - 0x00007ffa6ff82000 	C:\WINDOWS\System32\SHELL32.dll
+0x00007ffa6de40000 - 0x00007ffa6dfaa000 	C:\WINDOWS\System32\wintypes.dll
+0x00007ffa6e750000 - 0x00007ffa6efb3000 	C:\WINDOWS\System32\windows.storage.dll
+0x00007ffa6f730000 - 0x00007ffa6f826000 	C:\WINDOWS\System32\SHCORE.dll
+0x00007ffa70650000 - 0x00007ffa706b7000 	C:\WINDOWS\System32\shlwapi.dll
+0x00007ffa6db80000 - 0x00007ffa6dba9000 	C:\WINDOWS\SYSTEM32\profapi.dll
+0x00007ffa4c390000 - 0x00007ffa4c3a8000 	C:\Program Files\Java\jdk-17\bin\zip.dll
+0x00007ffa4ac40000 - 0x00007ffa4ac59000 	C:\Program Files\Java\jdk-17\bin\net.dll
+0x00007ffa64c50000 - 0x00007ffa64d77000 	C:\WINDOWS\SYSTEM32\WINHTTP.dll
+0x00007ffa6cf70000 - 0x00007ffa6cfdb000 	C:\WINDOWS\system32\mswsock.dll
+0x00007ffa40c90000 - 0x00007ffa40ca6000 	C:\Program Files\Java\jdk-17\bin\nio.dll
+0x00007ffa2ec50000 - 0x00007ffa2ec6a000 	C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.1\bin\breakgen64.dll
+0x00007ffa6c4d0000 - 0x00007ffa6c5fc000 	C:\WINDOWS\SYSTEM32\DNSAPI.dll
+0x00007ffa6c490000 - 0x00007ffa6c4c4000 	C:\WINDOWS\SYSTEM32\IPHLPAPI.DLL
+0x00007ffa6f720000 - 0x00007ffa6f72a000 	C:\WINDOWS\System32\NSI.dll
+0x00007ffa5cf80000 - 0x00007ffa5cf8b000 	C:\Windows\System32\rasadhlp.dll
+0x00007ffa65130000 - 0x00007ffa651b6000 	C:\WINDOWS\System32\fwpuclnt.dll
+0x00007ffa40500000 - 0x00007ffa4050a000 	C:\Program Files\Java\jdk-17\bin\management.dll
+0x00007ffa3bf00000 - 0x00007ffa3bf0b000 	C:\Program Files\Java\jdk-17\bin\management_ext.dll
+0x00007ffa6d240000 - 0x00007ffa6d25b000 	C:\WINDOWS\SYSTEM32\CRYPTSP.dll
+0x00007ffa6c960000 - 0x00007ffa6c999000 	C:\WINDOWS\system32\rsaenh.dll
+0x00007ffa6d020000 - 0x00007ffa6d04b000 	C:\WINDOWS\SYSTEM32\USERENV.dll
+0x00007ffa6db50000 - 0x00007ffa6db7a000 	C:\WINDOWS\SYSTEM32\bcrypt.dll
+0x00007ffa6d260000 - 0x00007ffa6d26c000 	C:\WINDOWS\SYSTEM32\CRYPTBASE.dll
+0x00007ffa64f90000 - 0x00007ffa64fae000 	C:\WINDOWS\SYSTEM32\dhcpcsvc6.DLL
+0x00007ffa64d80000 - 0x00007ffa64da3000 	C:\WINDOWS\SYSTEM32\dhcpcsvc.DLL
+0x00007ffa4b620000 - 0x00007ffa4b638000 	C:\WINDOWS\system32\napinsp.dll
+0x00007ffa4aba0000 - 0x00007ffa4abb2000 	C:\WINDOWS\System32\winrnr.dll
+0x00007ffa4ab70000 - 0x00007ffa4ab92000 	C:\WINDOWS\system32\nlansp_c.dll
+0x00007ffa5b360000 - 0x00007ffa5b376000 	C:\WINDOWS\system32\wshbth.dll
+0x00007ffa3bef0000 - 0x00007ffa3befe000 	C:\Program Files\Java\jdk-17\bin\sunmscapi.dll
+0x00007ffa6e5d0000 - 0x00007ffa6e747000 	C:\WINDOWS\System32\CRYPT32.dll
+0x00007ffa6d460000 - 0x00007ffa6d490000 	C:\WINDOWS\SYSTEM32\ncrypt.dll
+0x00007ffa6d410000 - 0x00007ffa6d44f000 	C:\WINDOWS\SYSTEM32\NTASN1.dll
+
+dbghelp: loaded successfully - version: 4.0.5 - missing functions: none
+symbol engine: initialized successfully - sym options: 0x614 - pdb path: .;C:\Program Files\Java\jdk-17\bin;C:\WINDOWS\SYSTEM32;C:\WINDOWS\WinSxS\amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.26100.7824_none_3e0870b2e3345462;C:\Program Files\Java\jdk-17\bin\server;C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.1\bin
+
+VM Arguments:
+jvm_args: -XX:TieredStopAtLevel=1 -Dspring.output.ansi.enabled=always -Dcom.sun.management.jmxremote -Dspring.jmx.enabled=true -Dspring.liveBeansView.mbeanDomain -Dspring.application.admin.enabled=true -Dmanagement.endpoints.jmx.exposure.include=* -javaagent:C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.1\lib\idea_rt.jar=59265:C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.1\bin -Dfile.encoding=UTF-8 
+java_command: com.moongeul.backend.BackendApplication
+java_class_path (initial): C:\GitHub_Repository\v2_Backend\build\classes\java\main;C:\GitHub_Repository\v2_Backend\build\resources\main;C:\Users\gogor\.gradle\caches\modules-2\files-2.1\org.projectlombok\lombok\1.18.42\8365263844ebb62398e0dc33057ba10ba472d3b8\lombok-1.18.42.jar;C:\Users\gogor\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter-web\3.5.7\b98c28da1fe667776698882c27f68630c2747b87\spring-boot-starter-web-3.5.7.jar;C:\Users\gogor\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter-security\3.5.7\6dee85a7ba008ff0dca8dbce5e68dca0c49a64cb\spring-boot-starter-security-3.5.7.jar;C:\Users\gogor\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter-data-jpa\3.5.7\5db48c2790037b07013a327871142e922247533a\spring-boot-starter-data-jpa-3.5.7.jar;C:\Users\gogor\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter-oauth2-client\3.5.7\3523d2a8357ea78d44adcb7205b6bc9c94582f2d\spring-boot-starter-oauth2-client-3.5.7.jar;C:\Users\gogor\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter-webflux\3.5.7\f919303a402d444e6402c97df00588dd960f924e\spring-boot-starter-webflux-3.5.7.jar;C:\Users\gogor\.gradle\caches\modules-2\files-2.1\org.springdoc\springdoc-openapi-starter-webmvc-ui\2.8.9\a05427a327a1e2c986c29b83632924a29616b400\springdoc-openapi-starter-webmvc-ui-2.8.9.jar;C:\Users\gogor\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter-validation\3.5.7\faff3bd84bcf3e880c4e95daa012feb85ba166dd\spring-boot-starter-validation-3.5.7.jar;C:\Users\gogor\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter\3.5.7\ea4a8ad9f4df7d94250d643aa278c3353cd88c5\spring-boot-starter-3.5.7.jar;C:\Users\gogor\.gradle\caches\modules-2\files-2.1\io.jsonwebtoken\jjwt-api\0.12.5\ea8243e36f16c2834ad69a048ed8a24aa9dd3e79\jjwt-api-0.12.5.jar;C:\Users\gogor\.gradle\caches\modules-2\files-2.1\org.springframework.
+Launcher Type: SUN_STANDARD
+
+[Global flags]
+     intx CICompilerCount                          = 4                                         {product} {ergonomic}
+     uint ConcGCThreads                            = 2                                         {product} {ergonomic}
+     uint G1ConcRefinementThreads                  = 8                                         {product} {ergonomic}
+   size_t G1HeapRegionSize                         = 1048576                                   {product} {ergonomic}
+    uintx GCDrainStackTargetSize                   = 64                                        {product} {ergonomic}
+   size_t InitialHeapSize                          = 130023424                                 {product} {ergonomic}
+     bool ManagementServer                         = true                                      {product} {command line}
+   size_t MarkStackSize                            = 4194304                                   {product} {ergonomic}
+   size_t MaxHeapSize                              = 2063597568                                {product} {ergonomic}
+   size_t MaxNewSize                               = 1237319680                                {product} {ergonomic}
+   size_t MinHeapDeltaBytes                        = 1048576                                   {product} {ergonomic}
+   size_t MinHeapSize                              = 8388608                                   {product} {ergonomic}
+    uintx NonProfiledCodeHeapSize                  = 0                                      {pd product} {ergonomic}
+     bool ProfileInterpreter                       = false                                  {pd product} {command line}
+    uintx ProfiledCodeHeapSize                     = 0                                      {pd product} {ergonomic}
+   size_t SoftMaxHeapSize                          = 2063597568                             {manageable} {ergonomic}
+     intx TieredStopAtLevel                        = 1                                         {product} {command line}
+     bool UseCompressedClassPointers               = true                           {product lp64_product} {ergonomic}
+     bool UseCompressedOops                        = true                           {product lp64_product} {ergonomic}
+     bool UseG1GC                                  = true                                      {product} {ergonomic}
+     bool UseLargePagesIndividualAllocation        = false                                  {pd product} {ergonomic}
+
+Logging:
+Log output configuration:
+ #0: stdout all=warning uptime,level,tags
+ #1: stderr all=off uptime,level,tags
+
+Environment Variables:
+JAVA_HOME=C:\Program Files\Java\jdk-17
+CLASSPATH=C:\Program Files\Java\jdk-17\lib
+PATH=C:\Program Files\Java\jdk-17\bin;C:\Program Files\Common Files\Oracle\Java\javapath;C:\windows\system32;C:\windows;C:\windows\System32\Wbem;C:\windows\System32\WindowsPowerShell\v1.0\;C:\windows\System32\OpenSSH\;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\Program Files\NVIDIA Corporation\NVIDIA NvDLISR;C:\Users\gogor\Desktop\Desktop_download\ffmpeg-6.0-essentials_build\ffmpeg-6.0-essentials_build\bin;C:\Program Files\Git LFS;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\Git\cmd;C:\Users\gogor\AppData\Local\Programs\Python\Python312;C:\Users\gogor\AppData\Local\Programs\Python\Python312\Scripts;C:\Program Files\dotnet\;C:\HashiCorp\Vagrant\bin;C:\Program Files\Oracle\VirtualBox;C:\Users\gogor\.local\bin;C:\Python\Python310\Scripts\;C:\Python\Python310\;C:\Users\gogor\AppData\Local\Microsoft\WindowsApps;C:\MinGW\bin;C:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2022.2.3\bin;C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.1\bin;C:\Users\gogor\AppData\Local\gitkraken\bin;C:\Users\gogor\AppData\Local\Programs\Microsoft VS Code\bin;C:\Users\gogor\AppData\Local\Microsoft\WindowsApps;C:\Users\gogor\AppData\Local\GitHubDesktop\bin
+USERNAME=gogor
+OS=Windows_NT
+PROCESSOR_IDENTIFIER=Intel64 Family 6 Model 140 Stepping 1, GenuineIntel
+
+
+
+---------------  S Y S T E M  ---------------
+
+OS:
+ Windows 11 , 64 bit Build 26100 (10.0.26100.7705)
+OS uptime: 4 days 19:01 hours
+Hyper-V role detected
+
+CPU: total 8 (initial active 8) (4 cores per cpu, 2 threads per core) family 6 model 140 stepping 1 microcode 0xb4, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, erms, clmul, bmi1, bmi2, adx, avx512f, avx512dq, avx512cd, avx512bw, avx512vl, sha, fma, vzeroupper, avx512_vpopcntdq, avx512_vpclmulqdq, avx512_vaes, avx512_vnni, clflush, clflushopt, clwb, avx512_vbmi2, avx512_vbmi, hv
+
+Memory: 4k page, system-wide physical 7865M (816M free)
+TotalPageFile size 20829M (AvailPageFile size 9M)
+current process WorkingSet (physical memory assigned to process): 229M, peak: 229M
+current process commit charge ("private bytes"): 327M, peak: 400M
+
+vm_info: Java HotSpot(TM) 64-Bit Server VM (17.0.11+7-LTS-207) for windows-amd64 JRE (17.0.11+7-LTS-207), built on Mar 11 2024 19:01:50 by "mach5one" with MS VC++ 17.6 (VS2022)
+
+END.

--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -239,6 +239,22 @@ public class MemberController {
         return ApiResponse.success(SuccessStatus.GET_FOLLOWER_SUCCESS, response);
     }
 
+    @Operation(
+            summary = "팔로우 승인/삭제 API",
+            description = "팔로우를 승인 또는 삭제하는 API 입니다." +
+                    "<br>status - 승인: ACCEPT / 삭제: DELETE 로 보내주시기 바랍니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "팔로우 승인/삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
+    })
+    @PostMapping("/follow/accept")
+    public ResponseEntity<ApiResponse<Void>> acceptFollow(@AuthenticationPrincipal UserDetails userDetails,
+                                                          @RequestBody AcceptFollowRequestDTO acceptFollowRequestDTO){
+        followService.acceptFollow(acceptFollowRequestDTO, userDetails.getUsername());
+        return ApiResponse.success_only(SuccessStatus.FOLLOW_PROCESS_SUCCESS);
+    }
+
     /*
      *
      * 닉네임 API

--- a/src/main/java/com/moongeul/backend/api/member/dto/AcceptFollowRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/AcceptFollowRequestDTO.java
@@ -1,0 +1,16 @@
+package com.moongeul.backend.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AcceptFollowRequestDTO {
+
+    private Long followerId; // 승인/삭제할 팔로워의 ID
+    private String status; // 처리 상태 (승인: ACCEPT / 삭제: DELETE)
+}

--- a/src/main/java/com/moongeul/backend/api/member/service/FollowService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/FollowService.java
@@ -1,6 +1,7 @@
 package com.moongeul.backend.api.member.service;
 
 
+import com.moongeul.backend.api.member.dto.AcceptFollowRequestDTO;
 import com.moongeul.backend.api.member.dto.FollowResponseDTO;
 import com.moongeul.backend.api.member.entity.Follow;
 import com.moongeul.backend.api.member.entity.FollowStatus;
@@ -8,6 +9,9 @@ import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.entity.PrivacyLevel;
 import com.moongeul.backend.api.member.repository.FollowRepository;
 import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.api.notification.entity.NotificationType;
+import com.moongeul.backend.api.notification.entity.Notifications;
+import com.moongeul.backend.api.notification.repository.NotificationRepository;
 import com.moongeul.backend.api.notification.service.NotificationTriggerService;
 import com.moongeul.backend.common.exception.BadRequestException;
 import com.moongeul.backend.common.exception.NotFoundException;
@@ -28,13 +32,14 @@ public class FollowService {
 
     private final FollowRepository followRepository;
     private final MemberRepository memberRepository;
+    private final NotificationRepository notificationRepository;
 
     private final NotificationTriggerService notificationTriggerService;
 
     /* 팔로우 API */
     @Transactional
     public void follow(Long following_id, String email){
-        Member following = getById(following_id); // 팔로우 대상
+        Member following = getMemberById(following_id); // 팔로우 대상
         Member follower = getMemberByEmail(email); // 나
 
         // 에러처리: 자기자신을 팔로우하는 경우 (불가)
@@ -137,7 +142,33 @@ public class FollowService {
                 .toList();
     }
 
-    private Member getById(Long id) {
+    /* 팔로우 승인 API */
+    @Transactional
+    public void acceptFollow(AcceptFollowRequestDTO acceptFollowRequestDTO, String email){
+
+        Member member = getMemberByEmail(email);
+
+        Follow follow = followRepository.findByFollowingIdAndFollowerId(member.getId(), acceptFollowRequestDTO.getFollowerId())
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.NO_FOLLOW_RELATIONSHIP.getMessage()));
+
+        // 알림 상태를 바꿔주기 위해
+        Notifications notifications = notificationRepository.findByReceiverIdAndActorIdAndType(member.getId(), acceptFollowRequestDTO.getFollowerId(), NotificationType.FOLLOW_PRIVATE)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.NOTIFICATION_NOTFOUND_EXCEPTION.getMessage()));
+
+        if(acceptFollowRequestDTO.getStatus().equals("ACCEPT")){
+            // '승인'한 경우 -> ACCEPTED 변경 + 알림 타입 변경
+            follow.accept();
+            notifications.switchNotificationType();
+        } else if(acceptFollowRequestDTO.getStatus().equals("DELETE")){
+            // '삭제'한 경우 -> 팔로우/알림 삭제
+            followRepository.delete(follow);
+            notificationRepository.delete(notifications);
+        } else{
+            throw new BadRequestException(ErrorStatus.BAD_FOLLOW_PROCESS_REQUEST.getMessage());
+        }
+    }
+
+    private Member getMemberById(Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
     }

--- a/src/main/java/com/moongeul/backend/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/moongeul/backend/api/notification/controller/NotificationController.java
@@ -1,17 +1,23 @@
 package com.moongeul.backend.api.notification.controller;
 
 import com.moongeul.backend.api.notification.dto.DeviceTokenRequestDTO;
+import com.moongeul.backend.api.notification.dto.NotificationsResponseDTO;
+import com.moongeul.backend.api.notification.dto.checkNotificationsResponseDTO;
 import com.moongeul.backend.api.notification.service.NotificationService;
+import com.moongeul.backend.api.notification.service.PushNotificationService;
 import com.moongeul.backend.common.response.ApiResponse;
 import com.moongeul.backend.common.response.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Notification", description = "Notification(푸시알람) 관련 API 입니다.")
 @RestController
@@ -19,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v2/notification")
 public class NotificationController {
 
+    private final PushNotificationService pushNotificationService;
     private final NotificationService notificationService;
 
     @Operation(
@@ -36,8 +43,42 @@ public class NotificationController {
     @PostMapping("/device-token")
     public ResponseEntity<ApiResponse<Void>> registerToken(@AuthenticationPrincipal UserDetails userDetails,
                                                            @RequestBody DeviceTokenRequestDTO requestDTO) {
-        notificationService.registerOrUpdateToken(userDetails.getUsername(), requestDTO);
+        pushNotificationService.registerOrUpdateToken(userDetails.getUsername(), requestDTO);
 
-        return ApiResponse.success_only(SuccessStatus.REGISTER_DEVICE_TOKEN);
+        return ApiResponse.success_only(SuccessStatus.REGISTER_DEVICE_TOKEN_SUCCESS);
+    }
+
+    @Operation(
+            summary = "미확인 알림 존재 여부 조회 API",
+            description = "미확인 알림이 존재하는지 여부(true/false)를 알 수 있습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "미확인 알림 존재 여부 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다."),
+    })
+    @GetMapping("/unread")
+    public ResponseEntity<ApiResponse<checkNotificationsResponseDTO>> checkUnReadNotifications(@AuthenticationPrincipal UserDetails userDetails) {
+
+        checkNotificationsResponseDTO response = notificationService.checkUnReadNotifications(userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.GET_UNREAD_NOTIFICATIONS_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "알림 내역 전체 조회 API",
+            description = "알림 페이지에 띄울 정보들을 전체 조회 합니다." +
+                    "<br>profileImage 값이 null인 것은 '서버공지'인 경우 입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 내역 전체 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다."),
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NotificationsResponseDTO>>> getNotifications(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false, defaultValue = "1") @Min(value = 1, message = "페이지는 1 이상이어야 합니다.(1부터 시작)") Integer page,
+            @RequestParam(required = false, defaultValue = "10") @Min(value = 1, message = "한 페이지당 개수는 1 이상이어야 합니다.") Integer size) {
+
+        List<NotificationsResponseDTO> response = notificationService.getNotifications(page, size, userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.GET_NOTIFICATIONS_SUCCESS, response);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/moongeul/backend/api/notification/controller/NotificationController.java
@@ -66,7 +66,15 @@ public class NotificationController {
     @Operation(
             summary = "알림 내역 전체 조회 API",
             description = "알림 페이지에 띄울 정보들을 전체 조회 합니다." +
-                    "<br>profileImage 값이 null인 것은 '서버공지'인 경우 입니다."
+                    "<br>- profileImage 값이 null인 것은 '서버공지'인 경우 입니다." +
+                    "<br>- 알림 유형이 'FOLLOW_PRIVATE'일 경우, 승인/삭제 버튼 필요" +
+                    "<br><br>[enum] 알림 유형 ->" +
+                    "<br>- NOTICE: 서버공지" +
+                    "<br>- LIKE: 공감 알림" +
+                    "<br>- COMMENT: 댓글 알림" +
+                    "<br>- FOLLOW_OPEN: 팔로우(공개 계정)" +
+                    "<br>- FOLLOW_PRIVATE: 팔로우(비공개 계정)" +
+                    "<br>- FOLLOW_PRIVATE_ACCEPTED: 팔로우(비공개 계정) - 승인됨"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 내역 전체 조회 성공"),

--- a/src/main/java/com/moongeul/backend/api/notification/dto/NotificationsResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/notification/dto/NotificationsResponseDTO.java
@@ -1,0 +1,27 @@
+package com.moongeul.backend.api.notification.dto;
+
+import com.moongeul.backend.api.notification.entity.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationsResponseDTO {
+
+    private Long id; // 알림 ID
+
+    private Long relatedId; // 연관된 ID값 (게시글ID, 회원ID 등)
+    private NotificationType notificationType; // 알림 타입 (LIKE, FOLLOW_OPEN ... 등)
+
+    private String profileImage;
+    private String content;
+    private LocalDateTime created_at;
+    
+    private boolean isRead; // 읽음 처리
+}

--- a/src/main/java/com/moongeul/backend/api/notification/dto/checkNotificationsResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/notification/dto/checkNotificationsResponseDTO.java
@@ -1,0 +1,16 @@
+package com.moongeul.backend.api.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class checkNotificationsResponseDTO {
+
+    private boolean exist; // 읽지 않은 알림 존재 여부(true/false)
+    private Long count; // 읽지 않은 알림 개수
+}

--- a/src/main/java/com/moongeul/backend/api/notification/entity/NotificationType.java
+++ b/src/main/java/com/moongeul/backend/api/notification/entity/NotificationType.java
@@ -11,7 +11,8 @@ public enum NotificationType {
     LIKE("공감 알림"),
     COMMENT("댓글 알림"),
     FOLLOW_OPEN("팔로우(공개 계정)"),
-    FOLLOW_PRIVATE("팔로우(비공개 계정)");
+    FOLLOW_PRIVATE("팔로우(비공개 계정)"),
+    FOLLOW_PRIVATE_ACCEPTED("팔로우(비공개 계정) - 승인됨");
 
     private final String key;
 }

--- a/src/main/java/com/moongeul/backend/api/notification/entity/Notifications.java
+++ b/src/main/java/com/moongeul/backend/api/notification/entity/Notifications.java
@@ -33,4 +33,8 @@ public class Notifications extends BaseTimeEntity {
     private Long relatedId; // 클릭 시 이동할 게시글 ID or 유저 ID or 공지사항 ID
 
     private boolean isRead; // 읽음 처리 여부
+
+    public void switchNotificationType(){
+        this.type = NotificationType.FOLLOW_PRIVATE_ACCEPTED;
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/moongeul/backend/api/notification/listener/NotificationEventListener.java
@@ -5,7 +5,7 @@ import com.moongeul.backend.api.notification.entity.NotificationType;
 import com.moongeul.backend.api.notification.event.AnswerNotificationEvent;
 import com.moongeul.backend.api.notification.event.FollowNotificationEvent;
 import com.moongeul.backend.api.notification.event.LikeNotificationEvent;
-import com.moongeul.backend.api.notification.service.NotificationService;
+import com.moongeul.backend.api.notification.service.PushNotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class NotificationEventListener { // 발행된 이벤트를 받아서 별도의 스레드에서 비동기적으로 알림을 저장하고 전송하는 클래스
 
-    private final NotificationService notificationService;
+    private final PushNotificationService pushNotificationService;
 
     /* 공감 알림 */
     @Async // 별도의 스레드에서 실행되도록 설정
@@ -24,7 +24,7 @@ public class NotificationEventListener { // 발행된 이벤트를 받아서 별
         String message = event.actor().getNickname() + "님이 회원님의 기록에 공감했습니다.";
 
         // 실제 DB 저장 및 Expo 푸시 알림 발송 로직 실행
-        notificationService.send(
+        pushNotificationService.send(
                 event.receiver(),
                 event.actor(),
                 NotificationType.LIKE,
@@ -40,7 +40,7 @@ public class NotificationEventListener { // 발행된 이벤트를 받아서 별
         String message = event.actor().getNickname() + "님이 회원님의 질문에 댓글을 달았습니다.";
 
         // 실제 DB 저장 및 Expo 푸시 알림 발송 로직 실행
-        notificationService.send(
+        pushNotificationService.send(
                 event.receiver(),
                 event.actor(),
                 NotificationType.LIKE,
@@ -63,7 +63,7 @@ public class NotificationEventListener { // 발행된 이벤트를 받아서 별
         }
 
         // 실제 DB 저장 및 Expo 푸시 알림 발송 로직 실행
-        notificationService.send(
+        pushNotificationService.send(
                 event.receiver(),
                 event.actor(),
                 notificationType,

--- a/src/main/java/com/moongeul/backend/api/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/moongeul/backend/api/notification/repository/NotificationRepository.java
@@ -1,8 +1,25 @@
 package com.moongeul.backend.api.notification.repository;
 
 import com.moongeul.backend.api.notification.entity.Notifications;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notifications, Long> {
+
+    Slice<Notifications> findByReceiverIdOrderByCreatedAtDesc(Long id, Pageable pageable);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Notifications n SET n.isRead = true WHERE n.receiver.id = :receiverId AND n.isRead = false")
+    void updateIsReadByReceiverId(@Param("receiverId") Long receiverId);
+
+    // 읽지 않은 알림이 있는지 여부 확인 (EXISTS 쿼리 사용으로 빠름)
+    boolean existsByReceiverIdAndReadFalse(Long receiverId);
+
+    // 읽지 않은 알림의 개수 확인
+    long countByReceiverIdAndReadFalse(Long receiverId);
 
 }

--- a/src/main/java/com/moongeul/backend/api/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/moongeul/backend/api/notification/repository/NotificationRepository.java
@@ -1,5 +1,6 @@
 package com.moongeul.backend.api.notification.repository;
 
+import com.moongeul.backend.api.notification.entity.NotificationType;
 import com.moongeul.backend.api.notification.entity.Notifications;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -7,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notifications, Long> {
 
@@ -17,9 +20,12 @@ public interface NotificationRepository extends JpaRepository<Notifications, Lon
     void updateIsReadByReceiverId(@Param("receiverId") Long receiverId);
 
     // 읽지 않은 알림이 있는지 여부 확인 (EXISTS 쿼리 사용으로 빠름)
-    boolean existsByReceiverIdAndReadFalse(Long receiverId);
+    boolean existsByReceiverIdAndIsReadFalse(Long receiverId);
 
     // 읽지 않은 알림의 개수 확인
-    long countByReceiverIdAndReadFalse(Long receiverId);
+    long countByReceiverIdAndIsReadFalse(Long receiverId);
+
+    // receiverId와 actorId로 FOLLOW_PRIVATE 알림 가져오기
+    Optional<Notifications> findByReceiverIdAndActorIdAndType(Long receiverId, Long actorId, NotificationType notificationType);
 
 }

--- a/src/main/java/com/moongeul/backend/api/notification/service/NotificationService.java
+++ b/src/main/java/com/moongeul/backend/api/notification/service/NotificationService.java
@@ -1,124 +1,76 @@
 package com.moongeul.backend.api.notification.service;
 
-import com.moongeul.backend.api.notification.dto.DeviceTokenRequestDTO;
-import com.moongeul.backend.api.notification.dto.ExpoPushRequestDTO;
-import com.moongeul.backend.api.notification.entity.DeviceToken;
-import com.moongeul.backend.api.notification.entity.NotificationType;
-import com.moongeul.backend.api.notification.entity.Notifications;
-import com.moongeul.backend.api.notification.repository.DeviceTokenRepository;
-import com.moongeul.backend.api.notification.repository.NotificationRepository;
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.api.notification.dto.NotificationsResponseDTO;
+import com.moongeul.backend.api.notification.dto.checkNotificationsResponseDTO;
+import com.moongeul.backend.api.notification.entity.Notifications;
+import com.moongeul.backend.api.notification.repository.NotificationRepository;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
-@Slf4j
 @RequiredArgsConstructor
 public class NotificationService {
 
-    private final DeviceTokenRepository deviceTokenRepository;
-    private final MemberRepository memberRepository;
     private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
 
-    private final WebClient webClient;
-    private static final String EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
-
-    /* 토큰 등록/수정 */
+    /* 알림 내역 전체 조회 */
     @Transactional
-    public void registerOrUpdateToken(String email, DeviceTokenRequestDTO deviceTokenRequestDTO) {
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    public List<NotificationsResponseDTO> getNotifications(Integer page, Integer size, String email){
+        Member member = getMemberByEmail(email);
 
-        // 1. 기존에 해당 토큰이 있는지 확인
-        deviceTokenRepository.findByToken(deviceTokenRequestDTO.getToken())
-                .ifPresentOrElse(
-                        // 2. 이미 있다면: 토큰의 주인이 바뀌었을 수 있으므로 업데이트
-                        existingToken -> {
-                            existingToken.updateMember(member);
-                        },
-                        // 3. 없다면: 새로운 DeviceToken 생성 및 저장
-                        () -> {
-                            DeviceToken newToken = DeviceToken.builder()
-                                    .member(member)
-                                    .token(deviceTokenRequestDTO.getToken())
-                                    .platform(deviceTokenRequestDTO.getPlatform())
-                                    .build();
-                            deviceTokenRepository.save(newToken);
-                        }
-                );
-    }
+        Pageable pageable = PageRequest.of(page - 1, size);
 
-    /* 알림 전송 */
-    @Transactional
-    public void send(Member receiver, Member actor, NotificationType notificationType, String message, Long relatedId) {
-        // 1. 알림 내역 DB 저장
-        Notifications notifications = Notifications.builder()
-                .receiver(receiver)
-                .actor(actor)
-                .content(message)
-                .type(notificationType)
-                .relatedId(relatedId)
-                .isRead(false)
-                .build();
-        notificationRepository.save(notifications);
+        Slice<Notifications> notificationsSlice = notificationRepository.findByReceiverIdOrderByCreatedAtDesc(member.getId(), pageable);
 
-        // 2. 수신자의 모든 디바이스 토큰 조회
-        List<String> tokenStrings = deviceTokenRepository.findAllByMemberId(receiver.getId())
-                .stream()
-                .map(DeviceToken::getToken)
+        List<NotificationsResponseDTO> response = notificationsSlice.getContent().stream()
+                .map(notification -> NotificationsResponseDTO.builder()
+                        .id(notification.getId())
+                        .relatedId(notification.getRelatedId())
+                        .notificationType(notification.getType())
+                        .profileImage(notification.getActor() != null ? notification.getActor().getProfileImage() : null) // profile 이미지 null -> 서버공지
+                        .content(notification.getContent())
+                        .created_at(notification.getCreatedAt())
+                        .isRead(notification.isRead())
+                        .build())
                 .collect(Collectors.toList());
 
-        // Expo 전송용 추가 데이터 구성
-        Map<String, Object> pushData = new HashMap<>();
-        pushData.put("type", notificationType);
-        pushData.put("id", relatedId);
+        // 해당 사용자의 알림 중 읽지 않은(isRead = false) 알림만 모두 true(읽음)로 변경
+        notificationRepository.updateIsReadByReceiverId(member.getId());
 
-        if (!tokenStrings.isEmpty()) {
-            // 3. WebClient로 비동기 전송
-            sendToExpo(tokenStrings, notificationType.getKey(), message, pushData);
-        }
+        return response;
     }
 
-    /* Expo Push API 호출 */
-    private void sendToExpo(List<String> targetTokens, String title, String body, Map<String, Object> pushData) {
-        // 페이로드 구성
-        ExpoPushRequestDTO requestPayload = ExpoPushRequestDTO.builder()
-                .to(targetTokens)
-                .title(title)
-                .body(body)
-                .sound("default")
-                .pushData(pushData)
-                .build();
-
-        webClient.post()
-                .uri(EXPO_PUSH_URL)
-                .bodyValue(requestPayload)
-                .retrieve()
-                .bodyToMono(Map.class) // 응답을 Map 형태로 받음
-                .subscribe(
-                        response -> log.info("Expo 푸시 전송 성공: {}", response),
-                        error -> log.error("Expo 푸시 전송 실패: {}", error.getMessage())
-                );
-    }
-
-    /* 로그아웃 시, 토큰 삭제 */
     @Transactional
-    public void removeDeviceToken(String token) {
-        // 토큰이 존재할 경우에만 삭제 진행
-        deviceTokenRepository.findByToken(token).ifPresent(deviceToken -> {
-            deviceTokenRepository.delete(deviceToken);
-            log.info("로그아웃으로 인한 디바이스 토큰 삭제 완료: {}", token);
-        });
+    public checkNotificationsResponseDTO checkUnReadNotifications(String email){
+        Member member = getMemberByEmail(email);
+
+        boolean isExist = notificationRepository.existsByReceiverIdAndReadFalse(member.getId());
+        Long count = notificationRepository.countByReceiverIdAndReadFalse(member.getId());
+
+        return checkNotificationsResponseDTO.builder()
+                .exist(isExist)
+                .count(count)
+                .build();
+    }
+
+    /*
+     * 단순 데이터 불러오기용 코드 메서드 - 코드 깔끔하게 하기용
+     */
+
+    private Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
     }
 }

--- a/src/main/java/com/moongeul/backend/api/notification/service/NotificationService.java
+++ b/src/main/java/com/moongeul/backend/api/notification/service/NotificationService.java
@@ -56,8 +56,8 @@ public class NotificationService {
     public checkNotificationsResponseDTO checkUnReadNotifications(String email){
         Member member = getMemberByEmail(email);
 
-        boolean isExist = notificationRepository.existsByReceiverIdAndReadFalse(member.getId());
-        Long count = notificationRepository.countByReceiverIdAndReadFalse(member.getId());
+        boolean isExist = notificationRepository.existsByReceiverIdAndIsReadFalse(member.getId());
+        Long count = notificationRepository.countByReceiverIdAndIsReadFalse(member.getId());
 
         return checkNotificationsResponseDTO.builder()
                 .exist(isExist)

--- a/src/main/java/com/moongeul/backend/api/notification/service/PushNotificationService.java
+++ b/src/main/java/com/moongeul/backend/api/notification/service/PushNotificationService.java
@@ -1,0 +1,122 @@
+package com.moongeul.backend.api.notification.service;
+
+import com.moongeul.backend.api.notification.dto.DeviceTokenRequestDTO;
+import com.moongeul.backend.api.notification.dto.ExpoPushRequestDTO;
+import com.moongeul.backend.api.notification.entity.DeviceToken;
+import com.moongeul.backend.api.notification.entity.NotificationType;
+import com.moongeul.backend.api.notification.entity.Notifications;
+import com.moongeul.backend.api.notification.repository.DeviceTokenRepository;
+import com.moongeul.backend.api.notification.repository.NotificationRepository;
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.common.exception.NotFoundException;
+import com.moongeul.backend.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PushNotificationService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final MemberRepository memberRepository;
+    private final NotificationRepository notificationRepository;
+
+    private final WebClient webClient;
+    private static final String EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
+
+    /* 토큰 등록/수정 */
+    @Transactional
+    public void registerOrUpdateToken(String email, DeviceTokenRequestDTO deviceTokenRequestDTO) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        // 1. 기존에 해당 토큰이 있는지 확인
+        deviceTokenRepository.findByToken(deviceTokenRequestDTO.getToken())
+                .ifPresentOrElse(
+                        // 2. 이미 있다면: 토큰의 주인이 바뀌었을 수 있으므로 업데이트
+                        existingToken -> existingToken.updateMember(member),
+                        // 3. 없다면: 새로운 DeviceToken 생성 및 저장
+                        () -> {
+                            DeviceToken newToken = DeviceToken.builder()
+                                    .member(member)
+                                    .token(deviceTokenRequestDTO.getToken())
+                                    .platform(deviceTokenRequestDTO.getPlatform())
+                                    .build();
+                            deviceTokenRepository.save(newToken);
+                        }
+                );
+    }
+
+    /* 알림 전송 */
+    @Transactional
+    public void send(Member receiver, Member actor, NotificationType notificationType, String message, Long relatedId) {
+        // 1. 알림 내역 DB 저장
+        Notifications notifications = Notifications.builder()
+                .receiver(receiver)
+                .actor(actor)
+                .content(message)
+                .type(notificationType)
+                .relatedId(relatedId)
+                .isRead(false)
+                .build();
+        notificationRepository.save(notifications);
+
+        // 2. 수신자의 모든 디바이스 토큰 조회
+        List<String> tokenStrings = deviceTokenRepository.findAllByMemberId(receiver.getId())
+                .stream()
+                .map(DeviceToken::getToken)
+                .collect(Collectors.toList());
+
+        // Expo 전송용 추가 데이터 구성
+        Map<String, Object> pushData = new HashMap<>();
+        pushData.put("type", notificationType);
+        pushData.put("id", relatedId);
+
+        if (!tokenStrings.isEmpty()) {
+            // 3. WebClient로 비동기 전송
+            sendToExpo(tokenStrings, notificationType.getKey(), message, pushData);
+        }
+    }
+
+    /* Expo Push API 호출 */
+    private void sendToExpo(List<String> targetTokens, String title, String body, Map<String, Object> pushData) {
+        // 페이로드 구성
+        ExpoPushRequestDTO requestPayload = ExpoPushRequestDTO.builder()
+                .to(targetTokens)
+                .title(title)
+                .body(body)
+                .sound("default")
+                .pushData(pushData)
+                .build();
+
+        webClient.post()
+                .uri(EXPO_PUSH_URL)
+                .bodyValue(requestPayload)
+                .retrieve()
+                .bodyToMono(Map.class) // 응답을 Map 형태로 받음
+                .subscribe(
+                        response -> log.info("Expo 푸시 전송 성공: {}", response),
+                        error -> log.error("Expo 푸시 전송 실패: {}", error.getMessage())
+                );
+    }
+
+    /* 로그아웃 시, 토큰 삭제 */
+    @Transactional
+    public void removeDeviceToken(String token) {
+        // 토큰이 존재할 경우에만 삭제 진행
+        deviceTokenRepository.findByToken(token).ifPresent(deviceToken -> {
+            deviceTokenRepository.delete(deviceToken);
+            log.info("로그아웃으로 인한 디바이스 토큰 삭제 완료: {}", token);
+        });
+    }
+}

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -50,6 +50,7 @@ public enum ErrorStatus {
     QUESTION_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 질문을 찾을 수 없습니다."),
     ANSWER_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 답변을 찾을 수 없습니다."),
     TERMS_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "약관 정보를 찾을 수 없습니다."),
+    NOTIFICATION_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 알림을 찾을 수 없습니다."),
 
     /**
      * 400 BAD_REQUEST
@@ -61,6 +62,7 @@ public enum ErrorStatus {
     NO_FOLLOW_RELATIONSHIP(HttpStatus.BAD_REQUEST, "팔로우 관계가 존재하지 않습니다."),
     EXISTS_FOLLOW_ACCEPTED(HttpStatus.BAD_REQUEST, "이미 팔로우하고 있는 사용자입니다."),
     EXISTS_FOLLOW_PENDING(HttpStatus.BAD_REQUEST, "이미 팔로우 요청을 보냈습니다. 승인을 기다려주세요."),
+    BAD_FOLLOW_PROCESS_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 팔로우 처리 요청입니다."),
     PRIVACY_FORBIDDEN_EXCEPTION(HttpStatus.FORBIDDEN, "해당 사용자의 정보는 공개되지 않습니다."),
 
     /**

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -24,6 +24,7 @@ public enum SuccessStatus {
 	UNFOLLOW_SUCCESS(HttpStatus.OK, "언팔로우 성공"),
 	GET_FOLLOWING_SUCCESS(HttpStatus.OK, "팔로잉 목록 조회 성공"),
 	GET_FOLLOWER_SUCCESS(HttpStatus.OK, "팔로워 목록 조회 성공"),
+	FOLLOW_PROCESS_SUCCESS(HttpStatus.OK, "팔로우 승인/삭제 성공"),
 	REGENERATE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 재생성 성공"),
 	UPDATE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 등록 성공"),
 	CHECK_NICKNAME_DUPLICATE_SUCCESS(HttpStatus.OK, "닉네임 중복 체크 성공"),

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -59,7 +59,9 @@ public enum SuccessStatus {
 	GET_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 전체 조회 성공"),
 
 	/* ALARM */
-	REGISTER_DEVICE_TOKEN(HttpStatus.OK, "사용자 기기 토큰 등록 성공"),
+	REGISTER_DEVICE_TOKEN_SUCCESS(HttpStatus.OK, "사용자 기기 토큰 등록 성공"),
+	GET_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "알림 내역 전체 조회 성공"),
+	GET_UNREAD_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "미확인 알림 존재 여부 조회 성공"),
 
 	/* QUESTION */
 	GET_QUESTION_LIST_SUCCESS(HttpStatus.OK, "질문 리스트 조회 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #89 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
1. 알림 페이지 전체 조회 API 구현
2. 메인 페이지 - 미확인 알림 존재 여부 API 구현
3. 팔로우(비공개 계정) 승인/삭제 API 구현

<br>

1. 알림 페이지 전체 조회 API 구현
- 스웨거에 적어둔 enum 값으로 알림 유형을 구분할 수 있습니다.
- `FOLLOW_PRIVATE` 유형은 컴포넌트에 '승인/삭제' 버튼이 필요합니다. 3번의 API를 사용하면 됩니다. 
  - 승인 시, `FOLLOW_PRIVATE_ACCEPTED`로 유형이 변경되므로 참고하여 컴포넌트 만들면 됩니다. 
  - 삭제 시, 새로고침 후 알림이 삭제됩니다. (DB삭제)

2. 메인 페이지 - 미확인 알림 존재 여부 API 구현
- 미확인 알림에 대한 디자인이 나오지 않아, 우선 미확인 알림 존재 여부(true/false)와 개수(count)를 둘 다 반환하도록 구현하였습니다.

3. 팔로우(비공개 계정) 승인/삭제 API 구현
- RequestDTO 필드 구성: follower의 id값과 status(처리상태)를 보냅니다.
- status는 승인: ACCEPT / 삭제: DELETE 로 보내면 처리됩니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[알림 페이지 전체 조회 API 구현]
<img width="921" height="548" alt="image" src="https://github.com/user-attachments/assets/6ebcbded-4c24-43bf-87b1-d1fc2e795f9f" />

[메인 페이지 - 미확인 알림 존재 여부 API 구현]
<img width="534" height="258" alt="image" src="https://github.com/user-attachments/assets/2aa2fb1f-e27f-49a8-adf3-56cb020c00f1" />

[팔로우(비공개 계정) 승인/삭제 API 구현]
<img width="782" height="547" alt="image" src="https://github.com/user-attachments/assets/b1843447-9697-4559-ba1c-107793603d4d" />
