### PR TITLE
[FIX] 검색 API 사용자 검색 확장 고도화

### DIFF
--- a/src/main/java/com/moongeul/backend/api/book/controller/BookController.java
+++ b/src/main/java/com/moongeul/backend/api/book/controller/BookController.java
@@ -3,16 +3,21 @@ package com.moongeul.backend.api.book.controller;
 import com.moongeul.backend.api.book.dto.BookDTO;
 import com.moongeul.backend.api.book.dto.BookSearchRequestDTO;
 import com.moongeul.backend.api.book.dto.BookSearchResponseDTO;
+import com.moongeul.backend.api.book.dto.BestsellerBookListResponseDTO;
+import com.moongeul.backend.api.book.dto.BestsellerRegisterRequestDTO;
 import com.moongeul.backend.api.book.service.BookService;
 import com.moongeul.backend.common.response.ApiResponse;
 import com.moongeul.backend.common.response.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -65,5 +70,37 @@ public class BookController {
         BookDTO bookDTO = bookService.getBookDetail(isbn);
         return ApiResponse.success(SuccessStatus.GET_BOOK_DETAIL_SUCCESS, bookDTO);
     }
-}
 
+    @Operation(
+            summary = "베스트셀러 도서 등록 API (관리자 전용)",
+            description = "관리자가 베스트셀러 도서를 ISBN 기준으로 최대 10권까지 등록합니다. 기존 목록은 새 목록으로 전체 교체됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "베스트셀러 도서 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 ISBN 리스트 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자만 접근할 수 있습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "등록하려는 도서를 찾을 수 없습니다.")
+    })
+    @PutMapping("/bestseller")
+    public ResponseEntity<ApiResponse<Void>> registerBestsellerBooks(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody BestsellerRegisterRequestDTO bestsellerRegisterRequestDTO) {
+
+        bookService.registerBestsellerBooks(userDetails.getUsername(), bestsellerRegisterRequestDTO);
+        return ApiResponse.success_only(SuccessStatus.REGISTER_BESTSELLER_BOOK_SUCCESS);
+    }
+
+    @Operation(
+            summary = "베스트셀러 도서 조회 API",
+            description = "등록된 베스트셀러 도서를 조회합니다. (최대 10권)"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "베스트셀러 도서 조회 성공")
+    })
+    @GetMapping("/bestseller")
+    public ResponseEntity<ApiResponse<BestsellerBookListResponseDTO>> getBestsellerBooks() {
+
+        BestsellerBookListResponseDTO bestsellerBookListResponseDTO = bookService.getBestsellerBooks();
+        return ApiResponse.success(SuccessStatus.GET_BESTSELLER_BOOK_SUCCESS, bestsellerBookListResponseDTO);
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/book/controller/BookController.java
+++ b/src/main/java/com/moongeul/backend/api/book/controller/BookController.java
@@ -31,22 +31,28 @@ public class BookController {
     private final BookService bookService;
 
     @Operation(
-            summary = "도서 검색 API",
-            description = "네이버 도서 API를 활용하여 책 제목으로 도서를 검색합니다. 검색 결과는 DB에 저장되며, 이미 저장된 도서는 최신 정보로 업데이트됩니다. (페이지와 사이즈는 1부터 시작합니다)"
+            summary = "도서/사용자 검색 API",
+            description = "검색어로 도서/사용자를 검색합니다." +
+                    "<br>- type=book: 도서만 검색" +
+                    "<br>- type=user: 사용자만 검색" +
+                    "<br>- type=all: 도서와 사용자 모두 검색" +
+                    "<br><br>도서 검색 결과는 DB에 저장되며, 이미 저장된 도서는 최신 정보로 업데이트됩니다. (페이지와 사이즈는 1부터 시작합니다)"
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "도서 검색 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "도서/사용자 검색 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
-    @GetMapping("/search")
+    @GetMapping("/user/search")
     public ResponseEntity<ApiResponse<BookSearchResponseDTO>> searchBooks(
             @RequestParam @NotBlank(message = "검색어는 필수입니다.") String query,
+            @RequestParam(required = false, defaultValue = "all") String type,
             @RequestParam(required = false, defaultValue = "1") @Min(value = 1, message = "페이지는 1 이상이어야 합니다.") Integer page,
             @RequestParam(required = false, defaultValue = "10") @Min(value = 1, message = "한 페이지당 개수는 1 이상이어야 합니다.") Integer size) {
         
         BookSearchRequestDTO bookSearchRequestDTO = BookSearchRequestDTO.builder()
                 .query(query)
+                .type(type)
                 .page(page)
                 .size(size)
                 .build();

--- a/src/main/java/com/moongeul/backend/api/book/dto/BestsellerBookItemDTO.java
+++ b/src/main/java/com/moongeul/backend/api/book/dto/BestsellerBookItemDTO.java
@@ -1,0 +1,18 @@
+package com.moongeul.backend.api.book.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BestsellerBookItemDTO {
+
+    private String isbn; // ISBN
+    private String bookImage; // 표지 이미지
+    private String title; // 책 제목
+    private String author; // 작가 이름
+}

--- a/src/main/java/com/moongeul/backend/api/book/dto/BestsellerBookListResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/book/dto/BestsellerBookListResponseDTO.java
@@ -1,0 +1,17 @@
+package com.moongeul.backend.api.book.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BestsellerBookListResponseDTO {
+
+    private List<BestsellerBookItemDTO> data;
+}

--- a/src/main/java/com/moongeul/backend/api/book/dto/BestsellerRegisterRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/book/dto/BestsellerRegisterRequestDTO.java
@@ -1,0 +1,22 @@
+package com.moongeul.backend.api.book.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BestsellerRegisterRequestDTO {
+
+    @NotNull(message = "ISBN 리스트는 필수입니다.")
+    @Size(min = 1, max = 10, message = "베스트셀러 도서는 1권 이상 10권 이하로 등록해야 합니다.")
+    private List<@NotBlank(message = "ISBN은 비어 있을 수 없습니다.") String> isbnList;
+}

--- a/src/main/java/com/moongeul/backend/api/book/dto/BookSearchRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/book/dto/BookSearchRequestDTO.java
@@ -15,11 +15,12 @@ public class BookSearchRequestDTO {
     @NotBlank(message = "검색어는 필수입니다.")
     private String query; // 검색어
 
+    private String type = "all"; // 검색 타입 (book, user, all)
+
     @Min(value = 1, message = "페이지는 1 이상이어야 합니다.")
     private Integer page = 1; // 페이지 번호 (기본값 1)
 
     @Min(value = 1, message = "한 페이지당 개수는 1 이상이어야 합니다.")
     private Integer size = 10; // 한 페이지당 개수 (기본값 10, 최대 100)
 }
-
 

--- a/src/main/java/com/moongeul/backend/api/book/dto/BookSearchResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/book/dto/BookSearchResponseDTO.java
@@ -12,11 +12,12 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class BookSearchResponseDTO {
+    private String type; // 검색 타입 (book, user, all)
     private Integer total; // 전체 검색 결과 수
     private Integer page; // 현재 페이지
     private Integer size; // 페이지당 개수
     private Integer totalPages; // 전체 페이지 수
     private Boolean isLast; // 마지막 페이지 여부
-    private List<BookDTO> data; // 책 목록
+    private List<BookDTO> bookData; // 책 목록
+    private List<BookSearchUserDTO> userData; // 사용자 목록
 }
-

--- a/src/main/java/com/moongeul/backend/api/book/dto/BookSearchUserDTO.java
+++ b/src/main/java/com/moongeul/backend/api/book/dto/BookSearchUserDTO.java
@@ -1,0 +1,19 @@
+package com.moongeul.backend.api.book.dto;
+
+import com.moongeul.backend.api.readingTaste.entity.ReadingTasteType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookSearchUserDTO {
+
+    private Long userId; // 사용자 ID
+    private String profileImage; // 사용자 프로필 이미지
+    private String nickname; // 사용자 닉네임
+    private ReadingTasteType readingTasteType; // 사용자 독서 취향
+}

--- a/src/main/java/com/moongeul/backend/api/book/entity/BestsellerBook.java
+++ b/src/main/java/com/moongeul/backend/api/book/entity/BestsellerBook.java
@@ -1,0 +1,27 @@
+package com.moongeul.backend.api.book.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "BESTSELLER_BOOK")
+public class BestsellerBook {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Integer sortOrder; // 노출 순서
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_isbn", nullable = false, unique = true)
+    private Book book;
+}

--- a/src/main/java/com/moongeul/backend/api/book/repository/BestsellerBookRepository.java
+++ b/src/main/java/com/moongeul/backend/api/book/repository/BestsellerBookRepository.java
@@ -1,0 +1,11 @@
+package com.moongeul.backend.api.book.repository;
+
+import com.moongeul.backend.api.book.entity.BestsellerBook;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BestsellerBookRepository extends JpaRepository<BestsellerBook, Long> {
+
+    List<BestsellerBook> findAllByOrderBySortOrderAsc();
+}

--- a/src/main/java/com/moongeul/backend/api/book/service/BookService.java
+++ b/src/main/java/com/moongeul/backend/api/book/service/BookService.java
@@ -1,27 +1,37 @@
 package com.moongeul.backend.api.book.service;
 
 import com.moongeul.backend.api.book.dto.*;
+import com.moongeul.backend.api.book.entity.BestsellerBook;
 import com.moongeul.backend.api.book.entity.Book;
+import com.moongeul.backend.api.book.repository.BestsellerBookRepository;
 import com.moongeul.backend.api.book.repository.BookRepository;
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.entity.Role;
+import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.common.exception.BadRequestException;
+import com.moongeul.backend.common.exception.ForbiddenException;
 import com.moongeul.backend.common.exception.InternalServerException;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,6 +41,8 @@ public class BookService {
 
     private final WebClient webClient;
     private final BookRepository bookRepository;
+    private final BestsellerBookRepository bestsellerBookRepository;
+    private final MemberRepository memberRepository;
 
     @Value("${naver.book.client-id}")
     private String clientId;
@@ -266,5 +278,85 @@ public class BookService {
         
         return convertToDTO(book);
     }
-}
 
+    // 베스트셀러 ISBN 등록 (관리자 전용)
+    @Transactional
+    public void registerBestsellerBooks(String email, BestsellerRegisterRequestDTO requestDTO) {
+        Member member = getMemberByEmail(email);
+        validateAdmin(member);
+
+        List<String> normalizedIsbnList = normalizeIsbnList(requestDTO.getIsbnList());
+        validateBestsellerIsbnList(normalizedIsbnList);
+
+        List<Book> books = bookRepository.findByIsbnIn(normalizedIsbnList);
+        Map<String, Book> bookMap = books.stream()
+                .collect(Collectors.toMap(Book::getIsbn, book -> book));
+
+        if (bookMap.size() != normalizedIsbnList.size()) {
+            throw new NotFoundException(ErrorStatus.BESTSELLER_BOOK_NOT_FOUND_EXCEPTION.getMessage());
+        }
+
+        bestsellerBookRepository.deleteAllInBatch();
+
+        List<BestsellerBook> bestsellerBooks = new ArrayList<>();
+        for (int i = 0; i < normalizedIsbnList.size(); i++) {
+            String isbn = normalizedIsbnList.get(i);
+            bestsellerBooks.add(BestsellerBook.builder()
+                    .sortOrder(i + 1)
+                    .book(bookMap.get(isbn))
+                    .build());
+        }
+
+        bestsellerBookRepository.saveAll(bestsellerBooks);
+    }
+
+    // 베스트셀러 조회
+    @Transactional(readOnly = true)
+    public BestsellerBookListResponseDTO getBestsellerBooks() {
+        List<BestsellerBookItemDTO> bookList = bestsellerBookRepository.findAllByOrderBySortOrderAsc().stream()
+                .map(bestsellerBook -> BestsellerBookItemDTO.builder()
+                        .isbn(bestsellerBook.getBook().getIsbn())
+                        .bookImage(bestsellerBook.getBook().getBookImage())
+                        .title(bestsellerBook.getBook().getTitle())
+                        .author(bestsellerBook.getBook().getAuthor())
+                        .build())
+                .toList();
+
+        return BestsellerBookListResponseDTO.builder()
+                .data(bookList)
+                .build();
+    }
+
+    private List<String> normalizeIsbnList(List<String> isbnList) {
+        List<String> normalizedList = new ArrayList<>();
+        for (String isbn : isbnList) {
+            if (!StringUtils.hasText(isbn)) {
+                throw new BadRequestException(ErrorStatus.BESTSELLER_INVALID_ISBN_EXCEPTION.getMessage());
+            }
+            normalizedList.add(isbn.trim());
+        }
+        return normalizedList;
+    }
+
+    private void validateBestsellerIsbnList(List<String> isbnList) {
+        if (isbnList.isEmpty() || isbnList.size() > 10) {
+            throw new BadRequestException(ErrorStatus.BESTSELLER_LIMIT_EXCEEDED_EXCEPTION.getMessage());
+        }
+
+        Set<String> isbnSet = new LinkedHashSet<>(isbnList);
+        if (isbnSet.size() != isbnList.size()) {
+            throw new BadRequestException(ErrorStatus.BESTSELLER_DUPLICATE_ISBN_EXCEPTION.getMessage());
+        }
+    }
+
+    private void validateAdmin(Member member) {
+        if (member.getRole() != Role.ADMIN) {
+            throw new ForbiddenException(ErrorStatus.ADMIN_FORBIDDEN_EXCEPTION.getMessage());
+        }
+    }
+
+    private Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    }
+}

--- a/src/main/java/com/moongeul/backend/api/book/service/BookService.java
+++ b/src/main/java/com/moongeul/backend/api/book/service/BookService.java
@@ -15,6 +15,9 @@ import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -27,9 +30,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -50,21 +53,57 @@ public class BookService {
     @Value("${naver.book.client-secret}")
     private String clientSecret;
 
-    // 도서 검색 메서드 (with 네이버 도서)
+    // 도서/사용자 통합 검색
     @Transactional
     public BookSearchResponseDTO searchBooks(BookSearchRequestDTO bookSearchRequestDTO) {
-        // 네이버 API 호출
+        String searchType = resolveSearchType(bookSearchRequestDTO.getType());
+
+        SearchPageResult<BookDTO> bookResult = SearchPageResult.empty();
+        SearchPageResult<BookSearchUserDTO> userResult = SearchPageResult.empty();
+
+        if ("book".equals(searchType) || "all".equals(searchType)) {
+            bookResult = searchBookData(bookSearchRequestDTO);
+        }
+
+        if ("user".equals(searchType) || "all".equals(searchType)) {
+            userResult = searchUserData(bookSearchRequestDTO);
+        }
+
+        int total;
+        int totalPages;
+        boolean isLast;
+
+        if ("book".equals(searchType)) {
+            total = bookResult.total;
+            totalPages = bookResult.totalPages;
+            isLast = bookResult.isLast;
+        } else if ("user".equals(searchType)) {
+            total = userResult.total;
+            totalPages = userResult.totalPages;
+            isLast = userResult.isLast;
+        } else {
+            total = bookResult.total + userResult.total;
+            totalPages = Math.max(bookResult.totalPages, userResult.totalPages);
+            isLast = bookResult.isLast && userResult.isLast;
+        }
+
+        return BookSearchResponseDTO.builder()
+                .type(searchType)
+                .total(total)
+                .page(bookSearchRequestDTO.getPage())
+                .size(bookSearchRequestDTO.getSize())
+                .totalPages(totalPages)
+                .isLast(isLast)
+                .bookData(bookResult.data)
+                .userData(userResult.data)
+                .build();
+    }
+
+    private SearchPageResult<BookDTO> searchBookData(BookSearchRequestDTO bookSearchRequestDTO) {
         NaverBookSearchResponseDTO naverBookSearchResponseDTO = callNaverBookAPI(bookSearchRequestDTO);
 
         if (naverBookSearchResponseDTO.getItems() == null || naverBookSearchResponseDTO.getItems().isEmpty()) {
-            return BookSearchResponseDTO.builder()
-                    .data(new ArrayList<>())
-                    .total(0)
-                    .page(bookSearchRequestDTO.getPage())
-                    .size(bookSearchRequestDTO.getSize())
-                    .totalPages(0)
-                    .isLast(true)
-                    .build();
+            return SearchPageResult.empty();
         }
 
         // ISBN 리스트 추출 (첫 번째 ISBN만 사용)
@@ -73,7 +112,6 @@ public class BookService {
                     if (item.getIsbn() == null || item.getIsbn().isEmpty()) {
                         return null;
                     }
-                    // 네이버 API는 여러 ISBN을 공백으로 구분하므로 첫 번째 ISBN만 사용
                     return item.getIsbn().split(" ")[0].trim();
                 })
                 .filter(isbn -> isbn != null && !isbn.isEmpty())
@@ -92,38 +130,55 @@ public class BookService {
                 continue;
             }
 
-            // ISBN에서 공백 제거 및 첫 번째 ISBN만 사용 (네이버 API는 여러 ISBN을 공백으로 구분)
             String isbn = naverItem.getIsbn().split(" ")[0].trim();
-
             Book book = existingBookMap.get(isbn);
-            
+
             if (book != null) {
-                // 기존 책이 있으면 업데이트 (최신 정보로)
                 updateBookIfChanged(book, naverItem);
             } else {
-                // 새 책이면 저장
                 book = saveNewBook(naverItem, isbn);
             }
 
             bookDTOs.add(convertToDTO(book));
         }
 
-        // 페이지네이션 정보 계산
         int total = naverBookSearchResponseDTO.getTotal() != null ? naverBookSearchResponseDTO.getTotal() : 0;
         int totalPages = (int) Math.ceil((double) total / bookSearchRequestDTO.getSize());
         int start = (bookSearchRequestDTO.getPage() - 1) * bookSearchRequestDTO.getSize() + 1;
-        
-        // 마지막 페이지 여부 계산
         boolean isLast = (start + bookSearchRequestDTO.getSize() - 1) >= total;
 
-        return BookSearchResponseDTO.builder()
-                .data(bookDTOs)
-                .total(total)
-                .page(bookSearchRequestDTO.getPage())
-                .size(bookSearchRequestDTO.getSize())
-                .totalPages(totalPages)
-                .isLast(isLast)
-                .build();
+        return SearchPageResult.of(total, totalPages, isLast, bookDTOs);
+    }
+
+    private SearchPageResult<BookSearchUserDTO> searchUserData(BookSearchRequestDTO bookSearchRequestDTO) {
+        Pageable pageable = PageRequest.of(bookSearchRequestDTO.getPage() - 1, bookSearchRequestDTO.getSize());
+        Page<Member> memberPage = memberRepository.findByNicknameContainingIgnoreCase(bookSearchRequestDTO.getQuery(), pageable);
+
+        List<BookSearchUserDTO> userDTOList = memberPage.getContent().stream()
+                .map(member -> BookSearchUserDTO.builder()
+                        .userId(member.getId())
+                        .profileImage(member.getProfileImage())
+                        .nickname(member.getNickname())
+                        .readingTasteType(member.getReadingTasteType())
+                        .build())
+                .toList();
+
+        return SearchPageResult.of(
+                (int) memberPage.getTotalElements(),
+                memberPage.getTotalPages(),
+                memberPage.isLast(),
+                userDTOList
+        );
+    }
+
+    private String resolveSearchType(String rawType) {
+        String type = StringUtils.hasText(rawType) ? rawType.trim().toLowerCase(Locale.ROOT) : "all";
+
+        if (!type.equals("book") && !type.equals("user") && !type.equals("all")) {
+            throw new BadRequestException(ErrorStatus.INVALID_SEARCH_TYPE_EXCEPTION.getMessage());
+        }
+
+        return type;
     }
 
     private NaverBookSearchResponseDTO callNaverBookAPI(BookSearchRequestDTO request) {
@@ -358,5 +413,27 @@ public class BookService {
     private Member getMemberByEmail(String email) {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    }
+
+    private static class SearchPageResult<T> {
+        private final int total;
+        private final int totalPages;
+        private final boolean isLast;
+        private final List<T> data;
+
+        private SearchPageResult(int total, int totalPages, boolean isLast, List<T> data) {
+            this.total = total;
+            this.totalPages = totalPages;
+            this.isLast = isLast;
+            this.data = data;
+        }
+
+        private static <T> SearchPageResult<T> of(int total, int totalPages, boolean isLast, List<T> data) {
+            return new SearchPageResult<>(total, totalPages, isLast, data);
+        }
+
+        private static <T> SearchPageResult<T> empty() {
+            return new SearchPageResult<>(0, 0, true, new ArrayList<>());
+        }
     }
 }

--- a/src/main/java/com/moongeul/backend/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/moongeul/backend/api/member/repository/MemberRepository.java
@@ -1,6 +1,8 @@
 package com.moongeul.backend.api.member.repository;
 
 import com.moongeul.backend.api.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -14,4 +16,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByRefreshToken(String refreshToken);
 
     Optional<Member> findByNickname(String nickname);
+
+    Page<Member> findByNicknameContainingIgnoreCase(String nickname, Pageable pageable);
 }

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -28,6 +28,9 @@ public enum ErrorStatus {
     DISAGREE_REQUIRED_TERM(HttpStatus.BAD_REQUEST, "필수 약관에 모두 동의해야 합니다."),
     PROFILE_IMAGE_EMPTY_EXCEPTION(HttpStatus.BAD_REQUEST, "업로드할 프로필 이미지가 없습니다."),
     PROFILE_IMAGE_INVALID_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "이미지 파일만 업로드할 수 있습니다."),
+    BESTSELLER_LIMIT_EXCEEDED_EXCEPTION(HttpStatus.BAD_REQUEST, "베스트셀러 도서는 1권 이상 10권 이하로 등록해야 합니다."),
+    BESTSELLER_DUPLICATE_ISBN_EXCEPTION(HttpStatus.BAD_REQUEST, "중복된 ISBN은 등록할 수 없습니다."),
+    BESTSELLER_INVALID_ISBN_EXCEPTION(HttpStatus.BAD_REQUEST, "ISBN 값이 올바르지 않습니다."),
 
     /**
      * 401 UNAUTHORIZED
@@ -50,6 +53,7 @@ public enum ErrorStatus {
     USER_READING_TASTE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "사용자의 독서 취향 정보를 찾을 수 없습니다."),
     WEEKLY_RECOMMENDATION_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "주간 추천 기록을 찾을 수 없습니다."),
     MOST_RECORDED_BOOK_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "가장 많이 기록된 책을 찾을 수 없습니다."),
+    BESTSELLER_BOOK_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "등록하려는 도서를 찾을 수 없습니다."),
     QUESTION_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 질문을 찾을 수 없습니다."),
     ANSWER_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 답변을 찾을 수 없습니다."),
     TERMS_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "약관 정보를 찾을 수 없습니다."),
@@ -69,6 +73,7 @@ public enum ErrorStatus {
     INVALID_RATING_RANGE_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 별점 구간입니다."),
     BAD_FOLLOW_PROCESS_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 팔로우 처리 요청입니다."),
     PRIVACY_FORBIDDEN_EXCEPTION(HttpStatus.FORBIDDEN, "해당 사용자의 정보는 공개되지 않습니다."),
+    ADMIN_FORBIDDEN_EXCEPTION(HttpStatus.FORBIDDEN, "관리자만 접근할 수 있습니다."),
 
     /**
      * 500 SERVER_ERROR

--- a/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/ErrorStatus.java
@@ -31,6 +31,7 @@ public enum ErrorStatus {
     BESTSELLER_LIMIT_EXCEEDED_EXCEPTION(HttpStatus.BAD_REQUEST, "베스트셀러 도서는 1권 이상 10권 이하로 등록해야 합니다."),
     BESTSELLER_DUPLICATE_ISBN_EXCEPTION(HttpStatus.BAD_REQUEST, "중복된 ISBN은 등록할 수 없습니다."),
     BESTSELLER_INVALID_ISBN_EXCEPTION(HttpStatus.BAD_REQUEST, "ISBN 값이 올바르지 않습니다."),
+    INVALID_SEARCH_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "검색 타입은 book, user, all 중 하나여야 합니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -40,6 +40,8 @@ public enum SuccessStatus {
 	/* BOOK */
 	SEARCH_BOOK_SUCCESS(HttpStatus.OK, "도서 검색 성공"),
 	GET_BOOK_DETAIL_SUCCESS(HttpStatus.OK, "도서 상세 조회 성공"),
+	REGISTER_BESTSELLER_BOOK_SUCCESS(HttpStatus.OK, "베스트셀러 도서 등록 성공"),
+	GET_BESTSELLER_BOOK_SUCCESS(HttpStatus.OK, "베스트셀러 도서 조회 성공"),
 	
 	/* BOOK REVIEW */
 	GET_BOOK_REVIEWS_SUCCESS(HttpStatus.OK, "책 리뷰 조회 성공"),

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -38,7 +38,7 @@ public enum SuccessStatus {
 	LINK_READING_TASTE_SUCCESS(HttpStatus.OK, "독서 취향 테스트 연동 성공"),
 
 	/* BOOK */
-	SEARCH_BOOK_SUCCESS(HttpStatus.OK, "도서 검색 성공"),
+	SEARCH_BOOK_SUCCESS(HttpStatus.OK, "도서/사용자 검색 성공"),
 	GET_BOOK_DETAIL_SUCCESS(HttpStatus.OK, "도서 상세 조회 성공"),
 	REGISTER_BESTSELLER_BOOK_SUCCESS(HttpStatus.OK, "베스트셀러 도서 등록 성공"),
 	GET_BESTSELLER_BOOK_SUCCESS(HttpStatus.OK, "베스트셀러 도서 조회 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #100

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기존 도서 검색 API를 확장하여 사용자도 동시에 조회하여 반환할 수 있도록 로직 개선하였습니다.
- 기존 /api/v2/book/search URI를 /api/v2/book/user/search로 변경하였습니다.
- 조회시 type을 추가하였습니다.
- 1. all : 도서, 사용자 동시 조회
- 2. user : 사용자만 조회
- 3. book : 도서만 조회

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 검색 API 수정 결과 ]
<img width="1416" height="741" alt="image" src="https://github.com/user-attachments/assets/e1c1fc6a-9c2a-46b9-b9c3-5fdb19f27c3e" />
