### PR TITLE
[FEAT] 마이페이지 - 내가 올린 질문카드 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -5,6 +5,8 @@ import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
 import com.moongeul.backend.api.member.service.FollowService;
 import com.moongeul.backend.api.member.service.MemberService;
 import com.moongeul.backend.api.post.dto.CategoryPostListResponseDTO;
+import com.moongeul.backend.api.question.dto.QuestionListResponseDTO;
+import com.moongeul.backend.api.question.service.QuestionService;
 import com.moongeul.backend.common.response.ApiResponse;
 import com.moongeul.backend.common.response.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,6 +31,7 @@ public class MemberController {
 
     private final MemberService memberService;
     private final FollowService followService;
+    private final QuestionService questionService;
 
     /*
      *
@@ -151,6 +154,26 @@ public class MemberController {
         CategoryPostListResponseDTO categoryPostListResponseDTO =
                 memberService.getCategoryPostList(userDetails.getUsername(), userId, categoryId, sortBy, page, size);
         return ApiResponse.success(SuccessStatus.GET_CATEGORY_POST_LIST_SUCCESS, categoryPostListResponseDTO);
+    }
+
+    @Operation(
+            summary = "마이페이지 질문 리스트 조회 API",
+            description = "사용자가 작성한 질문 리스트를 페이징하여 조회합니다. userId 쿼리파라미터가 없으면 본인 질문, 있으면 해당 사용자의 질문을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "마이페이지 질문 리스트 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
+    })
+    @GetMapping("/question-list")
+    public ResponseEntity<ApiResponse<QuestionListResponseDTO>> getMyQuestionList(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(defaultValue = "1") Integer page,
+            @RequestParam(defaultValue = "10") Integer size) {
+
+        QuestionListResponseDTO questionListResponseDTO =
+                questionService.getMyQuestionList(page, size, userDetails.getUsername(), userId);
+        return ApiResponse.success(SuccessStatus.GET_MY_QUESTION_LIST_SUCCESS, questionListResponseDTO);
     }
 
     @Operation(

--- a/src/main/java/com/moongeul/backend/api/question/repository/QuestionRepository.java
+++ b/src/main/java/com/moongeul/backend/api/question/repository/QuestionRepository.java
@@ -11,4 +11,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long>  {
     // 질문 전체 조회 (최신순)
     @Query("SELECT q FROM Question q ORDER BY q.createdAt DESC")
     Page<Question> findAllQuestions(Pageable pageable);
+
+    // 특정 사용자가 작성한 질문 조회 (최신순)
+    Page<Question> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
@@ -76,6 +76,34 @@ public class QuestionService {
                 .build();
     }
 
+    // 마이페이지 질문 리스트 조회
+    public QuestionListResponseDTO getMyQuestionList(Integer page, Integer size, String email, Long userId) {
+
+        Member currentMember = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        Member targetMember = (userId == null)
+                ? currentMember
+                : memberRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Question> questionPage = questionRepository.findByMemberIdOrderByCreatedAtDesc(targetMember.getId(), pageable);
+
+        List<QuestionDTO> questionDTOList = questionPage.getContent().stream()
+                .map(question -> convertToQuestionDTO(question, email))
+                .collect(Collectors.toList());
+
+        return QuestionListResponseDTO.builder()
+                .total(questionPage.getTotalElements())
+                .page(page)
+                .size(size)
+                .totalPages(questionPage.getTotalPages())
+                .isLast(questionPage.isLast())
+                .data(questionDTOList)
+                .build();
+    }
+
     // 질문 상세 조회
     public QuestionDTO getQuestionDetail(Long questionId, String email) {
 

--- a/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
@@ -2,7 +2,11 @@ package com.moongeul.backend.api.question.service;
 
 import com.moongeul.backend.api.book.entity.Book;
 import com.moongeul.backend.api.book.repository.BookRepository;
+import com.moongeul.backend.api.member.entity.Follow;
+import com.moongeul.backend.api.member.entity.FollowStatus;
 import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.entity.PrivacyLevel;
+import com.moongeul.backend.api.member.repository.FollowRepository;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.api.question.dto.QuestionCreateRequestDTO;
 import com.moongeul.backend.api.question.dto.QuestionDTO;
@@ -12,6 +16,7 @@ import com.moongeul.backend.api.question.dto.QuestionModifyRequestDTO;
 import com.moongeul.backend.api.question.entity.Question;
 import com.moongeul.backend.api.question.repository.AnswerRepository;
 import com.moongeul.backend.api.question.repository.QuestionRepository;
+import com.moongeul.backend.common.exception.ForbiddenException;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.exception.UnauthorizedException;
 import com.moongeul.backend.common.response.ErrorStatus;
@@ -34,6 +39,7 @@ import java.util.stream.Collectors;
 public class QuestionService {
 
     private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
     private final BookRepository bookRepository;
     private final QuestionRepository questionRepository;
     private final AnswerRepository answerRepository;
@@ -87,6 +93,8 @@ public class QuestionService {
                 : memberRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
 
+        validatePrivacyAccess(currentMember, targetMember);
+
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<Question> questionPage = questionRepository.findByMemberIdOrderByCreatedAtDesc(targetMember.getId(), pageable);
 
@@ -102,6 +110,32 @@ public class QuestionService {
                 .isLast(questionPage.isLast())
                 .data(questionDTOList)
                 .build();
+    }
+
+    private void validatePrivacyAccess(Member currentMember, Member targetMember) {
+        if (currentMember.getId().equals(targetMember.getId())) {
+            return;
+        }
+
+        PrivacyLevel privacyLevel = targetMember.getPrivacyLevel();
+
+        if (privacyLevel == null || privacyLevel == PrivacyLevel.PUBLIC) {
+            return;
+        }
+
+        if (privacyLevel == PrivacyLevel.PRIVATE) {
+            throw new ForbiddenException(ErrorStatus.PRIVACY_FORBIDDEN_EXCEPTION.getMessage());
+        }
+
+        if (privacyLevel == PrivacyLevel.FOLLOWER_ONLY) {
+            FollowStatus status = followRepository.findByFollowingIdAndFollowerId(targetMember.getId(), currentMember.getId())
+                    .map(Follow::getFollowStatus)
+                    .orElse(FollowStatus.NONE);
+
+            if (status != FollowStatus.ACCEPTED) {
+                throw new ForbiddenException(ErrorStatus.PRIVACY_FORBIDDEN_EXCEPTION.getMessage());
+            }
+        }
     }
 
     // 질문 상세 조회

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -75,6 +75,7 @@ public enum SuccessStatus {
 
 	/* QUESTION */
 	GET_QUESTION_LIST_SUCCESS(HttpStatus.OK, "질문 리스트 조회 성공"),
+	GET_MY_QUESTION_LIST_SUCCESS(HttpStatus.OK, "마이페이지 질문 리스트 조회 성공"),
 	GET_QUESTION_DETAIL_SUCCESS(HttpStatus.OK, "질문 상세 조회 성공"),
 	MODIFY_QUESTION_SUCCESS(HttpStatus.OK, "질문 수정 성공"),
 	DELETE_QUESTION_SUCCESS(HttpStatus.OK, "질문 삭제 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #102

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 마이페이지에 있는 내가 올린 질문들을 조회하는 기능을 구현하였습니다.
- 사용자ID를 받는 쿼리파라미터를 넣을 시 해당 사용자가 작성한 질문들을 조회하는 기능을 구현하였습니다.
- 타 사용자 조회 시 해당 계정의 공개 범위에 따라 필터링하는 기능을 구현하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 마이페이지 질문 조회 결과 ]
<img width="1416" height="697" alt="image" src="https://github.com/user-attachments/assets/cbc219d1-8156-4182-bccb-6a3147870240" />

[ 필터링 결과 ]
<img width="1416" height="676" alt="image" src="https://github.com/user-attachments/assets/7090ad4d-04fa-479d-8c0e-4ef92395ba60" />
