### PR TITLE
[FIX] 읽은 책장 관련 API - 타 사용자 조회 가능하게 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/bookshelf/controller/DoneReadBookshelfController.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/controller/DoneReadBookshelfController.java
@@ -30,57 +30,65 @@ public class DoneReadBookshelfController {
 
     @Operation(
             summary = "읽은 책장 전체 조회 API",
-            description = "인증된 사용자의 읽은 책장 목록을 최신순으로 조회합니다. (페이지와 사이즈는 1부터 시작합니다)"
+            description = "읽은 책장 목록을 최신순으로 조회합니다. userId 쿼리파라미터가 없으면 본인, 있으면 해당 사용자의 읽은 책장을 조회합니다. (페이지와 사이즈는 1부터 시작합니다)"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "읽은 책장 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 사용자의 정보는 공개되지 않습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.")
     })
     @GetMapping
     public ResponseEntity<ApiResponse<DoneReadBookshelfResponseDTO>> getDoneReadBooks(
             @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) Long userId,
             @RequestParam(required = false, defaultValue = "1") @Min(value = 1, message = "페이지는 1 이상이어야 합니다.") Integer page,
             @RequestParam(required = false, defaultValue = "10") @Min(value = 1, message = "한 페이지당 개수는 1 이상이어야 합니다.") Integer size) {
         
-        DoneReadBookshelfResponseDTO doneReadBookshelfResponseDTO = doneReadBookshelfService.getDoneReadBooks(userDetails.getUsername(), page, size);
+        DoneReadBookshelfResponseDTO doneReadBookshelfResponseDTO =
+                doneReadBookshelfService.getDoneReadBooks(userDetails.getUsername(), userId, page, size);
         return ApiResponse.success(SuccessStatus.GET_DONE_READ_BOOKS_SUCCESS, doneReadBookshelfResponseDTO);
     }
 
     @Operation(
             summary = "읽은 책 캘린더 조회 API",
-            description = "입력한 연/월 기준으로 일자별 읽은 책 정보를 조회합니다. " +
+            description = "입력한 연/월 기준으로 일자별 읽은 책 정보를 조회합니다. userId 쿼리파라미터가 없으면 본인, 있으면 해당 사용자의 정보를 조회합니다. " +
                     "같은 날짜에 여러 권이 있으면 가장 최근에 작성된 기록의 표지를 대표로 반환하고 count로 개수를 제공합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "읽은 책 캘린더 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 사용자의 정보는 공개되지 않습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.")
     })
     @GetMapping("/calendar")
     public ResponseEntity<ApiResponse<DoneReadCalendarResponseDTO>> getDoneReadCalendar(
             @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) Long userId,
             @RequestParam @Min(value = 1, message = "연도는 1 이상이어야 합니다.") Integer year,
             @RequestParam @Min(value = 1, message = "월은 1 이상이어야 합니다.") @Max(value = 12, message = "월은 12 이하여야 합니다.") Integer month) {
 
         DoneReadCalendarResponseDTO doneReadCalendar = doneReadBookshelfService.getDoneReadCalendar(
-                userDetails.getUsername(), year, month);
+                userDetails.getUsername(), userId, year, month);
         return ApiResponse.success(SuccessStatus.GET_DONE_READ_CALENDAR_SUCCESS, doneReadCalendar);
     }
 
     @Operation(
             summary = "읽은 책 별점 요약 조회 API",
-            description = "사용자가 기록한 총 책 수와 별점 구간(1.0~1.4, 1.5~1.9, ... , 4.5~5.0)별 기록 수를 조회합니다."
+            description = "사용자가 기록한 총 책 수와 별점 구간(1.0~1.4, 1.5~1.9, ... , 4.5~5.0)별 기록 수를 조회합니다. userId 쿼리파라미터가 없으면 본인, 있으면 해당 사용자의 정보를 조회합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "읽은 책 별점 요약 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 사용자의 정보는 공개되지 않습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.")
     })
     @GetMapping("/rating-summary")
     public ResponseEntity<ApiResponse<DoneReadRatingSummaryResponseDTO>> getDoneReadRatingSummary(
-            @AuthenticationPrincipal UserDetails userDetails) {
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) Long userId) {
 
-        DoneReadRatingSummaryResponseDTO doneReadRatingSummaryResponseDTO = doneReadBookshelfService.getDoneReadRatingSummary(userDetails.getUsername());
+        DoneReadRatingSummaryResponseDTO doneReadRatingSummaryResponseDTO =
+                doneReadBookshelfService.getDoneReadRatingSummary(userDetails.getUsername(), userId);
         return ApiResponse.success(SuccessStatus.GET_DONE_READ_RATING_SUMMARY_SUCCESS, doneReadRatingSummaryResponseDTO);
     }
 
@@ -98,18 +106,20 @@ public class DoneReadBookshelfController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "읽은 책 별점 구간 상세 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 별점 구간입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 사용자의 정보는 공개되지 않습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.")
     })
     @GetMapping("/rating-summary/details")
     public ResponseEntity<ApiResponse<CategoryPostListResponseDTO>> getDoneReadRatingDetail(
             @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) Long userId,
             @RequestParam String range,
             @RequestParam(defaultValue = "LATEST") String sortBy,
             @RequestParam(defaultValue = "1") @Min(value = 1, message = "페이지는 1 이상이어야 합니다.") Integer page,
             @RequestParam(defaultValue = "10") @Min(value = 1, message = "한 페이지당 개수는 1 이상이어야 합니다.") Integer size) {
 
         CategoryPostListResponseDTO categoryPostListResponseDTO =
-                doneReadBookshelfService.getDoneReadRatingDetail(userDetails.getUsername(), range, sortBy, page, size);
+                doneReadBookshelfService.getDoneReadRatingDetail(userDetails.getUsername(), userId, range, sortBy, page, size);
         return ApiResponse.success(SuccessStatus.GET_DONE_READ_RATING_DETAIL_SUCCESS, categoryPostListResponseDTO);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/bookshelf/service/DoneReadBookshelfService.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/service/DoneReadBookshelfService.java
@@ -9,7 +9,11 @@ import com.moongeul.backend.api.bookshelf.dto.DoneReadRatingRangeCountDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadRatingSummaryResponseDTO;
 import com.moongeul.backend.api.bookshelf.entity.DoneReadBookshelf;
 import com.moongeul.backend.api.bookshelf.repository.DoneReadBookshelfRepository;
+import com.moongeul.backend.api.member.entity.Follow;
+import com.moongeul.backend.api.member.entity.FollowStatus;
 import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.entity.PrivacyLevel;
+import com.moongeul.backend.api.member.repository.FollowRepository;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.api.post.dto.CategoryPostListResponseDTO;
 import com.moongeul.backend.api.post.dto.PostDTO;
@@ -18,6 +22,7 @@ import com.moongeul.backend.api.post.entity.Quote;
 import com.moongeul.backend.api.post.repository.PostRepository;
 import com.moongeul.backend.api.post.repository.QuoteRepository;
 import com.moongeul.backend.common.exception.BadRequestException;
+import com.moongeul.backend.common.exception.ForbiddenException;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +50,7 @@ public class DoneReadBookshelfService {
 
     private final DoneReadBookshelfRepository doneReadBookshelfRepository;
     private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
     private final PostRepository postRepository;
     private final QuoteRepository quoteRepository;
     private static final String[] RATING_RANGES = {
@@ -55,10 +61,8 @@ public class DoneReadBookshelfService {
     private static final double[] RANGE_ENDS = {1.4, 1.9, 2.4, 2.9, 3.4, 3.9, 4.4, 5.0};
 
     @Transactional(readOnly = true)
-    public DoneReadBookshelfResponseDTO getDoneReadBooks(String email, Integer page, Integer size) {
-
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    public DoneReadBookshelfResponseDTO getDoneReadBooks(String email, Long userId, Integer page, Integer size) {
+        Member member = getTargetMember(email, userId);
 
         // 페이지네이션 설정
         Pageable pageable = PageRequest.of(page - 1, size);
@@ -87,10 +91,8 @@ public class DoneReadBookshelfService {
 
     // 읽은 책 캘린더 조회
     @Transactional(readOnly = true)
-    public DoneReadCalendarResponseDTO getDoneReadCalendar(String email, Integer year, Integer month) {
-
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    public DoneReadCalendarResponseDTO getDoneReadCalendar(String email, Long userId, Integer year, Integer month) {
+        Member member = getTargetMember(email, userId);
 
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDate startDate = yearMonth.atDay(1);
@@ -156,10 +158,8 @@ public class DoneReadBookshelfService {
 
     // 읽은 책 별점 요약 조회
     @Transactional(readOnly = true)
-    public DoneReadRatingSummaryResponseDTO getDoneReadRatingSummary(String email) {
-
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    public DoneReadRatingSummaryResponseDTO getDoneReadRatingSummary(String email, Long userId) {
+        Member member = getTargetMember(email, userId);
 
         long totalBooks = doneReadBookshelfRepository.countByMember(member);
         List<Double> ratings = postRepository.findRatingsByMember(member);
@@ -194,10 +194,8 @@ public class DoneReadBookshelfService {
 
     // 읽은 책 별점 구간 상세 조회
     @Transactional(readOnly = true)
-    public CategoryPostListResponseDTO getDoneReadRatingDetail(String email, String range, String sortBy, Integer page, Integer size) {
-
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    public CategoryPostListResponseDTO getDoneReadRatingDetail(String email, Long userId, String range, String sortBy, Integer page, Integer size) {
+        Member member = getTargetMember(email, userId);
 
         int rangeIndex = findRangeIndex(range);
         Pageable pageable = PageRequest.of(page - 1, size, resolveSort(sortBy));
@@ -316,6 +314,45 @@ public class DoneReadBookshelfService {
         }
 
         throw new BadRequestException(ErrorStatus.INVALID_RATING_RANGE_EXCEPTION.getMessage());
+    }
+
+    private Member getTargetMember(String email, Long userId) {
+        Member currentMember = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        Member targetMember = (userId == null)
+                ? currentMember
+                : memberRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        validatePrivacyAccess(currentMember, targetMember);
+        return targetMember;
+    }
+
+    private void validatePrivacyAccess(Member currentMember, Member targetMember) {
+        if (currentMember.getId().equals(targetMember.getId())) {
+            return;
+        }
+
+        PrivacyLevel privacyLevel = targetMember.getPrivacyLevel();
+
+        if (privacyLevel == null || privacyLevel == PrivacyLevel.PUBLIC) {
+            return;
+        }
+
+        if (privacyLevel == PrivacyLevel.PRIVATE) {
+            throw new ForbiddenException(ErrorStatus.PRIVACY_FORBIDDEN_EXCEPTION.getMessage());
+        }
+
+        if (privacyLevel == PrivacyLevel.FOLLOWER_ONLY) {
+            FollowStatus status = followRepository.findByFollowingIdAndFollowerId(targetMember.getId(), currentMember.getId())
+                    .map(Follow::getFollowStatus)
+                    .orElse(FollowStatus.NONE);
+
+            if (status != FollowStatus.ACCEPTED) {
+                throw new ForbiddenException(ErrorStatus.PRIVACY_FORBIDDEN_EXCEPTION.getMessage());
+            }
+        }
     }
 
     private static class CalendarDayAggregate {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #104

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 읽은 책장의 조회 API들을 userId 파라미터를 받아서 해당 사용자의 책장을 볼 수 있도록 기능을 수정하였습니다.
- 해당 계정의 정보 공개 여부에 따라 필터링 하는 기능도 추가하였습니다.
 
## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 수정한 API 목록 ]
<img width="1434" height="275" alt="image" src="https://github.com/user-attachments/assets/7ab8d152-0127-4100-95e6-a73c02f09f4e" />

[ 필터링 시 ]
<img width="1416" height="665" alt="image" src="https://github.com/user-attachments/assets/8e807202-7be4-4692-96e8-476e4f012695" />

[ 타인 조회 시 ]
<img width="1416" height="680" alt="image" src="https://github.com/user-attachments/assets/2e71e62f-d0b3-4cf5-bd61-d9267a0ac207" />
