### PR TITLE
[FEAT] 탈퇴하기 및 로그아웃 API 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/bookshelf/repository/DoneReadBookshelfRepository.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/repository/DoneReadBookshelfRepository.java
@@ -6,6 +6,7 @@ import com.moongeul.backend.api.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,4 +20,9 @@ public interface DoneReadBookshelfRepository extends JpaRepository<DoneReadBooks
     Optional<DoneReadBookshelf> findByMemberAndBook(@Param("member") Member member, @Param("book") Book book);
 
     long countByMember(Member member);
+
+    // 회원 탈퇴 시, 해당 회원의 읽은 책 삭제
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM DoneReadBookshelf d WHERE d.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/moongeul/backend/api/bookshelf/repository/WishReadBookshelfRepository.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/repository/WishReadBookshelfRepository.java
@@ -6,6 +6,7 @@ import com.moongeul.backend.api.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,5 +20,10 @@ public interface WishReadBookshelfRepository extends JpaRepository<WishReadBooks
     
     @Query("SELECT w FROM WishReadBookshelf w WHERE w.member = :member ORDER BY w.createdAt DESC")
     Page<WishReadBookshelf> findByMemberOrderByCreatedAtDesc(@Param("member") Member member, Pageable pageable);
+
+    // 회원 탈퇴 시, 해당 회원의 읽고싶은 책 삭제
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM WishReadBookshelf w WHERE w.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }
 

--- a/src/main/java/com/moongeul/backend/api/category/repository/CategoryRepository.java
+++ b/src/main/java/com/moongeul/backend/api/category/repository/CategoryRepository.java
@@ -4,6 +4,9 @@ package com.moongeul.backend.api.category.repository;
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +14,9 @@ import java.util.Optional;
 public interface CategoryRepository extends JpaRepository<Category, Long>  {
 
     Optional<List<Category>> findByMember(Member member);
+
+    // 회원 탈퇴 시 해당 회원이 생성한 모든 카테고리 삭제
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Category c WHERE c.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -109,6 +109,69 @@ public class MemberController {
         return ApiResponse.success(SuccessStatus.GET_USERINFO_SUCCESS, response);
     }
 
+    /*
+     *
+     * 로그아웃 API
+     *
+     * */
+    @Operation(
+            summary = "로그아웃 API",
+            description = "사용자의 계정을 로그아웃합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공")
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal UserDetails userDetails,
+                                                    @RequestBody LogoutRequestDTO logoutRequestDTO) {
+
+        memberService.logout(userDetails.getUsername(), logoutRequestDTO.getDeviceToken());
+        return ApiResponse.success_only(SuccessStatus.LOGOUT_SUCCESS);
+    }
+
+    /*
+     *
+     * 토큰 재발급 API
+     *
+     * */
+    @Operation(
+            summary = "토큰 재발급 API",
+            description = "엑세스 토큰 만료 시, 유효한 리프레시 토큰을 통해 엑세스 토큰을 재발급 받습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "토큰이 만료되었거나 유효하지 않은 토큰입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
+    })
+    @GetMapping("/reissue-token")
+    public ResponseEntity<ApiResponse<JwtTokenDTO>> reissueAccessToken(@RequestHeader(value = "Authorization-Refresh") String refreshToken){
+        JwtTokenDTO response = memberService.reissueToken(refreshToken);
+        return ApiResponse.success(SuccessStatus.REISSUE_TOKEN_SUCCESS, response);
+    }
+
+    /**
+     * 회원 탈퇴 API
+     */
+    @Operation(
+            summary = "회원 탈퇴 API",
+            description = "회원의 계정을 탈퇴처리합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다."),
+    })
+    @PostMapping("/withdraw")
+    public ResponseEntity<ApiResponse<Void>> withdraw(@AuthenticationPrincipal UserDetails userDetails,
+                                                             @RequestBody WithdrawalRequestDTO withdrawalRequestDTO){
+        memberService.withdraw(userDetails.getUsername(), withdrawalRequestDTO);
+        return ApiResponse.success_only(SuccessStatus.WITHDRAW_SUCCESS);
+    }
+
+    /*
+     *
+     * 마이페이지 관련 API
+     *
+     * */
     @Operation(
             summary = "기록 통계 조회 API (마이페이지 기록장)",
             description = "사용자의 기록 작성 통계를 조회합니다. userId 쿼리 파라미터가 없으면 본인 정보를 조회하고, 있으면 해당 사용자의 정보를 조회합니다. " +
@@ -202,21 +265,6 @@ public class MemberController {
         QuestionListResponseDTO questionListResponseDTO =
                 questionService.getMyQuestionList(page, size, userDetails.getUsername(), userId);
         return ApiResponse.success(SuccessStatus.GET_MY_QUESTION_LIST_SUCCESS, questionListResponseDTO);
-    }
-
-    @Operation(
-            summary = "토큰 재발급 API",
-            description = "엑세스 토큰 만료 시, 유효한 리프레시 토큰을 통해 엑세스 토큰을 재발급 받습니다."
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "토큰이 만료되었거나 유효하지 않은 토큰입니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.")
-    })
-    @GetMapping("/reissue-token")
-    public ResponseEntity<ApiResponse<JwtTokenDTO>> reissueAccessToken(@RequestHeader(value = "Authorization-Refresh") String refreshToken){
-        JwtTokenDTO response = memberService.reissueToken(refreshToken);
-        return ApiResponse.success(SuccessStatus.REISSUE_TOKEN_SUCCESS, response);
     }
 
     /*

--- a/src/main/java/com/moongeul/backend/api/member/dto/LogoutRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/LogoutRequestDTO.java
@@ -1,0 +1,15 @@
+package com.moongeul.backend.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LogoutRequestDTO {
+
+    private String deviceToken;
+}

--- a/src/main/java/com/moongeul/backend/api/member/dto/WithdrawalRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/WithdrawalRequestDTO.java
@@ -1,0 +1,16 @@
+package com.moongeul.backend.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WithdrawalRequestDTO {
+
+    private String reason; // 탈퇴 사유
+    private String detailReason; // 상세 사유
+}

--- a/src/main/java/com/moongeul/backend/api/member/entity/Member.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/Member.java
@@ -94,4 +94,17 @@ public class Member extends BaseTimeEntity {
     public void updatePrivacy(PrivacyLevel level) {
         this.privacyLevel = level;
     }
+
+    /**
+     * 회원 탈퇴 시 개인정보를 지우는 메서드
+     */
+    public void withdrawMember() {
+        this.socialId = null;        // 재가입 가능하도록 null 처리
+        this.refreshToken = null;
+        this.nickname = "(알 수 없음)";
+        this.profileImage = null;
+        this.name = null;            // 실명 정보 삭제
+        this.email = "withdrawn_" + this.id + "@moongeul.com"; // 이메일 중복 방지를 위해 식별 가능한 값으로 변경
+        this.role = Role.GUEST;      // 권한 축소
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/member/entity/Withdrawal.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/Withdrawal.java
@@ -1,0 +1,33 @@
+package com.moongeul.backend.api.member.entity;
+
+import com.moongeul.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder // 빌더 패턴 사용을 위한 롬복 애너테이션
+@NoArgsConstructor // 기본 생성자
+@AllArgsConstructor // 모든 필드를 포함한 생성자
+@Table(name = "WITHDRAWAL") // 데이터베이스 테이블 이름 지정
+public class Withdrawal extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email; // 재가입 방지 확인용
+
+    @Column(nullable = false)
+    private String reason; // 탈퇴 사유 (선택한 항목 또는 기타 입력값)
+    private String detailReason; // 상세 탈퇴 사유
+
+    @Column(nullable = false)
+    private LocalDateTime withdrawalDate; // 탈퇴 시점
+}

--- a/src/main/java/com/moongeul/backend/api/member/repository/FollowRepository.java
+++ b/src/main/java/com/moongeul/backend/api/member/repository/FollowRepository.java
@@ -2,6 +2,7 @@ package com.moongeul.backend.api.member.repository;
 
 import com.moongeul.backend.api.member.entity.Follow;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -26,4 +27,14 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     // 4. 내가 팔로우를 건 모든 기록 (상태 상관 x)
     // 팔로워 목록에서 '내가 그들에게 보낸 상태'를 확인하기 위해 필요
     List<Follow> findAllByFollowerId(Long followerId);
+
+    // 회원 탈퇴 시, 내가 팔로우한 기록 삭제 (내가 follower인 경우)
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Follow f WHERE f.follower.id = :memberId")
+    void deleteAllByFollowerId(@Param("memberId") Long memberId);
+
+    // 회원 탈퇴 시, 나를 팔로우한 기록 삭제 (내가 following인 경우)
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Follow f WHERE f.following.id = :memberId")
+    void deleteAllByFollowingId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/moongeul/backend/api/member/repository/WithdrawalRepository.java
+++ b/src/main/java/com/moongeul/backend/api/member/repository/WithdrawalRepository.java
@@ -1,0 +1,7 @@
+package com.moongeul.backend.api.member.repository;
+
+import com.moongeul.backend.api.member.entity.Withdrawal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WithdrawalRepository extends JpaRepository<Withdrawal, Long> {
+}

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -218,6 +218,8 @@ public class MemberService {
     public void withdraw(String email, WithdrawalRequestDTO withdrawalRequestDTO) {
 
         Member member = getMemberByEmail(email);
+        String profileImageUrl = member.getProfileImage();
+        String targetDomain = "https://api-bucket.rhkr8521.com";
 
         /* 1. 벌크 삭제 쿼리 실행 (각 Repository에 작성된 @Modifying 쿼리 호출) - 호출 순서 중요! */
         // [팔로우] 내가 팔로우한 & 나를 팔로우한 사람들 삭제
@@ -260,7 +262,12 @@ public class MemberService {
                 .build();
         withdrawalRepository.save(withdrawal);
 
-        // 탈퇴 이므로, 공개 상태를 PRIVATE 으로 변경
+        // 버킷 내 이미지 삭제
+        if (profileImageUrl != null && profileImageUrl.startsWith(targetDomain)) {
+            log.info("탈퇴 회원 프로필 버킷 이미지 삭제: {}", profileImageUrl);
+            fileUploadService.deleteFileByUrl(profileImageUrl);
+        }
+        // 공개 상태를 PRIVATE 으로 변경
         member.updatePrivacy(PrivacyLevel.PRIVATE);
         // 3. Member 정보 초기화
         member.withdrawMember();

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.moongeul.backend.api.member.service;
 
+import com.moongeul.backend.api.bookshelf.repository.DoneReadBookshelfRepository;
+import com.moongeul.backend.api.bookshelf.repository.WishReadBookshelfRepository;
 import com.moongeul.backend.api.category.entity.Category;
 import com.moongeul.backend.api.category.repository.CategoryRepository;
 import com.moongeul.backend.api.member.dto.*;
@@ -7,7 +9,10 @@ import com.moongeul.backend.api.member.entity.*;
 import com.moongeul.backend.api.member.jwt.dto.JwtTokenDTO;
 import com.moongeul.backend.api.member.repository.FollowRepository;
 import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.api.member.repository.WithdrawalRepository;
 import com.moongeul.backend.api.member.util.NicknameGenerator;
+import com.moongeul.backend.api.notification.repository.DeviceTokenRepository;
+import com.moongeul.backend.api.notification.repository.NotificationRepository;
 import com.moongeul.backend.api.post.dto.CategoryPostListResponseDTO;
 import com.moongeul.backend.api.post.dto.PostDTO;
 import com.moongeul.backend.api.post.entity.Post;
@@ -15,6 +20,9 @@ import com.moongeul.backend.api.post.entity.Quote;
 import com.moongeul.backend.api.post.repository.PostRepository;
 import com.moongeul.backend.api.post.repository.QuoteRepository;
 import com.moongeul.backend.api.book.entity.Book;
+import com.moongeul.backend.api.question.repository.AnswerRepository;
+import com.moongeul.backend.api.question.repository.QuestionRepository;
+import com.moongeul.backend.api.setting.repository.AgreeRepository;
 import com.moongeul.backend.common.config.jwt.JwtTokenProvider;
 import com.moongeul.backend.common.exception.BadRequestException;
 import com.moongeul.backend.common.exception.ForbiddenException;
@@ -32,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -45,6 +54,15 @@ public class MemberService {
     private final CategoryRepository categoryRepository;
     private final PostRepository postRepository;
     private final QuoteRepository quoteRepository;
+    private final WithdrawalRepository withdrawalRepository;
+    private final NotificationRepository notificationRepository;
+    private final AnswerRepository answerRepository;
+    private final DoneReadBookshelfRepository doneReadBookshelfRepository;
+    private final WishReadBookshelfRepository wishReadBookshelfRepository;
+    private final QuestionRepository questionRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final AgreeRepository agreeRepository;
+
     private final JwtTokenProvider jwtTokenProvider;
     private final GoogleOAuthService googleOAuthService;
     private final KakaoOAuthService kakaoOAuthService;
@@ -179,6 +197,75 @@ public class MemberService {
                 .myFollowStatus(myFollowStatus)
                 .privacyLevel(member.getPrivacyLevel() == null ? PrivacyLevel.PUBLIC : member.getPrivacyLevel())
                 .build();
+    }
+
+    /* 로그아웃 API */
+    @Transactional
+    public void logout(String email, String deviceToken) {
+        Member member = getMemberByEmail(email);
+
+        // 리프레시 토큰 null 처리
+        member.updateRefreshToken(null);
+
+        // 현재 기기의 디바이스 토큰만 삭제 (알림 차단)
+        if (deviceToken != null) {
+            deviceTokenRepository.deleteByToken(deviceToken);
+        }
+    }
+
+    /* 탈퇴하기 API - soft delete 처리 */
+    @Transactional
+    public void withdraw(String email, WithdrawalRequestDTO withdrawalRequestDTO) {
+
+        Member member = getMemberByEmail(email);
+
+        /* 1. 벌크 삭제 쿼리 실행 (각 Repository에 작성된 @Modifying 쿼리 호출) - 호출 순서 중요! */
+        // [팔로우] 내가 팔로우한 & 나를 팔로우한 사람들 삭제
+        followRepository.deleteAllByFollowerId(member.getId());
+        followRepository.deleteAllByFollowingId(member.getId());
+
+        // [디바이스토큰]
+        deviceTokenRepository.deleteAllByMemberId(member.getId());
+
+        // [약관 동의]
+        agreeRepository.deleteAllByMemberId(member.getId());
+
+        // [알림] 내가 받은 알림만 삭제
+        notificationRepository.deleteAllByReceiverId(member.getId());
+
+        // [답변] 내가 쓴 답변 & 내 질문에 달린 답변 삭제
+        answerRepository.deleteAllByMemberId(member.getId());
+        answerRepository.deleteAllByQuestionMemberId(member.getId());
+
+        // [질문]
+        questionRepository.deleteAllByMemberId(member.getId());
+
+        // [책장]
+        doneReadBookshelfRepository.deleteAllByMemberId(member.getId());
+        wishReadBookshelfRepository.deleteAllByMemberId(member.getId());
+
+        // [게시글 & 인용구]
+        quoteRepository.deleteAllByMemberId(member.getId()); // Post 이전에 삭제
+        postRepository.deleteAllByMemberId(member.getId());
+
+        // [카테고리] Post가 모두 삭제된 후 삭제 가능
+        categoryRepository.deleteAllByMemberId(member.getId());
+
+        // 2. 탈퇴 이력 저장 (나중에 통계 및 재가입 방지 체크에 사용)
+        Withdrawal withdrawal = Withdrawal.builder()
+                .email(email)
+                .reason(withdrawalRequestDTO.getReason()) // 예: "기타"
+                .detailReason(withdrawalRequestDTO.getDetailReason()) // 예: "이유작성완료"
+                .withdrawalDate(LocalDateTime.now())
+                .build();
+        withdrawalRepository.save(withdrawal);
+
+        // 탈퇴 이므로, 공개 상태를 PRIVATE 으로 변경
+        member.updatePrivacy(PrivacyLevel.PRIVATE);
+        // 3. Member 정보 초기화
+        member.withdrawMember();
+
+        memberRepository.saveAndFlush(member);
     }
 
     /* 기록 통계 조회 (마이페이지 기록장) */

--- a/src/main/java/com/moongeul/backend/api/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/moongeul/backend/api/notification/repository/DeviceTokenRepository.java
@@ -2,6 +2,9 @@ package com.moongeul.backend.api.notification.repository;
 
 import com.moongeul.backend.api.notification.entity.DeviceToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +18,9 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> 
 
     // 로그아웃 시 특정 토큰 삭제
     void deleteByToken(String token);
+
+    // 회원 탈퇴 시 해당 회원의 모든 디바이스 토큰 삭제
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM DeviceToken dt WHERE dt.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/moongeul/backend/api/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/moongeul/backend/api/notification/repository/NotificationRepository.java
@@ -28,4 +28,8 @@ public interface NotificationRepository extends JpaRepository<Notifications, Lon
     // receiverId와 actorId로 FOLLOW_PRIVATE 알림 가져오기
     Optional<Notifications> findByReceiverIdAndActorIdAndType(Long receiverId, Long actorId, NotificationType notificationType);
 
+    // 회원 탈퇴 시 해당 회원의 모든 알림 삭제
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Notifications n WHERE n.receiver.id = :memberId")
+    void deleteAllByReceiverId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
@@ -8,6 +8,7 @@ import com.moongeul.backend.api.post.entity.PostVisibility;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -126,4 +127,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Double> findRatingsByMember(@Param("member") Member member);
 
     Page<Post> findByMemberAndRatingBetween(Member member, Double startRating, Double endRating, Pageable pageable);
+
+    // 회원 탈퇴 시 작성한 모든 게시글 삭제
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Post p WHERE p.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/moongeul/backend/api/post/repository/QuoteRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/QuoteRepository.java
@@ -2,6 +2,9 @@ package com.moongeul.backend.api.post.repository;
 
 import com.moongeul.backend.api.post.entity.Quote;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,4 +13,10 @@ public interface QuoteRepository extends JpaRepository<Quote, Long> {
     List<Quote> findByPostId(Long postId);
 
     void deleteAllByPostId(Long postId);
+
+    // 회원 탈퇴 시, 해당 회원이 작성한 모든 게시글의 인용구 삭제
+    // Post 테이블과 조인해 해당 멤버의 게시글에 속한 인용구들만 타겟팅
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Quote q WHERE q.post.id IN (SELECT p.id FROM Post p WHERE p.member.id = :memberId)")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/moongeul/backend/api/question/repository/AnswerRepository.java
+++ b/src/main/java/com/moongeul/backend/api/question/repository/AnswerRepository.java
@@ -5,6 +5,7 @@ import com.moongeul.backend.api.question.entity.Answer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -24,4 +25,15 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     // 특정 질문의 답변 리스트 조회 (페이징, 최신순)
     @Query("SELECT a FROM Answer a WHERE a.question.id = :questionId ORDER BY a.createdAt DESC")
     Page<Answer> findByQuestionId(@Param("questionId") Long questionId, Pageable pageable);
+
+    // 회원 탈퇴 시, 해당 회원이 작성한 모든 답변 삭제
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Answer a WHERE a.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
+
+    // 회원 탈퇴 시 해당 회원이 작성한 '질문'에 달린 모든 답변 삭제
+    // 부모인 질문 삭제 전에 먼저 정리해야 함
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Answer a WHERE a.question.id IN (SELECT q.id FROM Question q WHERE q.member.id = :memberId)")
+    void deleteAllByQuestionMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/moongeul/backend/api/question/repository/QuestionRepository.java
+++ b/src/main/java/com/moongeul/backend/api/question/repository/QuestionRepository.java
@@ -4,7 +4,9 @@ import com.moongeul.backend.api.question.entity.Question;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface QuestionRepository extends JpaRepository<Question, Long>  {
 
@@ -14,4 +16,9 @@ public interface QuestionRepository extends JpaRepository<Question, Long>  {
 
     // 특정 사용자가 작성한 질문 조회 (최신순)
     Page<Question> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+
+    // 회원 탈퇴 시, 해당 회원이 작성한 모든 질문 삭제
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Question q WHERE q.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/moongeul/backend/api/setting/repository/AgreeRepository.java
+++ b/src/main/java/com/moongeul/backend/api/setting/repository/AgreeRepository.java
@@ -4,10 +4,18 @@ import com.moongeul.backend.api.setting.entity.Agree;
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.setting.entity.Terms;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface AgreeRepository extends JpaRepository<Agree, Long> {
 
     Optional<Agree> findByMemberAndTerms(Member member, Terms terms);
+
+    // 회원 탈퇴 시 해당 회원의 모든 약관 동의 기록 삭제
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Agree a WHERE a.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -31,6 +31,8 @@ public enum SuccessStatus {
 	GET_PRIVACY_LEVEL_SUCCESS(HttpStatus.OK, "계정 공개 범위 조회 성공"),
 	UPDATE_PRIVACY_LEVEL_SUCCESS(HttpStatus.OK, "계정 공개 범위 수정 성공"),
 	TERMS_AGREE_SUCCESS(HttpStatus.OK, "약관 동의 성공"),
+	LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공"),
+	WITHDRAW_SUCCESS(HttpStatus.OK, "회원 탈퇴 성공"),
 
 	/* READING TASTE */
 	CALCULATE_READING_TASTE_SUCCESS(HttpStatus.OK, "독서 취향 테스트 결과 계산 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #108 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
1. 계정 탈퇴하기 API를 구현하였습니다.
  - 서비스 정책에 따라, 탈퇴 시 계정의 모든 정보(팔로우, 디바이스토큰, 약관동의, 알림, 답변, 질문, 책장, 게시글&인용구, 카테고리)를 삭제 처리합니다. (이때, like와 취향테스트 결과는 삭제되지 않습니다.)
  - Member 정보 삭제는 `hard delete`가 아닌 `soft delete` 기술을 적용하였습니다. privacy_level -> PRIVATE 처리 후 기타 칼럼값을 `null`처리합니다. nickname은 '(알 수 없음)'으로 변경 처리하였습니다.
  - 탈퇴 사유&탈퇴 시점과 향후 재가입 대조를 위해 email 정보를 `withdrawal` 테이블에 저장합니다.
  - 현재 `1개월 간 서비스 재가입 불가능` 기능은 개발하지 않았으니 이 점 참고 바랍니다. (테스트 필요 및 기획적 고려 이유 등)

2. 로그아웃 API를 구현하였습니다.
  - 로그아웃 시, Member 테이블의 refreshToken 필드를 null 처리합니다.
  - API 사용 시, 푸시 알림 해제를 위해 deviceToken을 넘겨주어야 합니다. (로그아웃한 디바이스의 알림을 해제 시킴 - 토큰 삭제)

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[탈퇴 API]
<img width="724" height="543" alt="image" src="https://github.com/user-attachments/assets/911641d9-b32b-4c6a-b597-9c8ab07e99df" />
[로그아웃 API]
<img width="694" height="542" alt="image" src="https://github.com/user-attachments/assets/77d3b251-66f0-4a5b-8d9b-dd700c860b16" />
