### PR TITLE
[FEAT] 푸시알림허용 on/off 기능 API 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/dto/UserInfoDTO.java
+++ b/src/main/java/com/moongeul/backend/api/member/dto/UserInfoDTO.java
@@ -19,4 +19,5 @@ public class UserInfoDTO {
     private final Integer followingCount; // 팔로잉 수
     private final FollowStatus myFollowStatus; // 내가 해당 사용자를 팔로우했는지 여부
     private final PrivacyLevel privacyLevel; // 계정 공개 범위
+    private final boolean isPushEnabled; // 푸시 알림 허용 여부
 }

--- a/src/main/java/com/moongeul/backend/api/member/entity/Member.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/Member.java
@@ -44,6 +44,10 @@ public class Member extends BaseTimeEntity {
 
     private String refreshToken; // Refresh Token
 
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean isPushEnabled = true; // 푸시알림 허용, 기본값: ON
+
     /**
      * 권한 가져오기
      */
@@ -93,5 +97,12 @@ public class Member extends BaseTimeEntity {
      */
     public void updatePrivacy(PrivacyLevel level) {
         this.privacyLevel = level;
+    }
+
+    /**
+     * 푸시 알림 허용 업데이트
+     */
+    public void updatePushEnabled(boolean isPushEnabled) {
+        this.isPushEnabled = isPushEnabled;
     }
 }

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -142,7 +142,7 @@ public class MemberService {
         return memberRepository.save(newUser);
     }
 
-    // 사용자 정보 조회
+    /* 사용자 정보 조회 */
     @Transactional(readOnly = true)
     public UserInfoDTO getUserInfo(String email, Long userId){
 
@@ -178,6 +178,7 @@ public class MemberService {
                 .followingCount(followingCount)
                 .myFollowStatus(myFollowStatus)
                 .privacyLevel(member.getPrivacyLevel() == null ? PrivacyLevel.PUBLIC : member.getPrivacyLevel())
+                .isPushEnabled(member.isPushEnabled())
                 .build();
     }
 

--- a/src/main/java/com/moongeul/backend/api/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/moongeul/backend/api/notification/listener/NotificationEventListener.java
@@ -25,8 +25,8 @@ public class NotificationEventListener { // 발행된 이벤트를 받아서 별
 
         // 실제 DB 저장 및 Expo 푸시 알림 발송 로직 실행
         pushNotificationService.send(
-                event.receiver(),
-                event.actor(),
+                event.receiver().getId(),
+                event.actor().getId(),
                 NotificationType.LIKE,
                 message,
                 event.post().getId()
@@ -41,8 +41,8 @@ public class NotificationEventListener { // 발행된 이벤트를 받아서 별
 
         // 실제 DB 저장 및 Expo 푸시 알림 발송 로직 실행
         pushNotificationService.send(
-                event.receiver(),
-                event.actor(),
+                event.receiver().getId(),
+                event.actor().getId(),
                 NotificationType.LIKE,
                 message,
                 event.question().getId()
@@ -64,8 +64,8 @@ public class NotificationEventListener { // 발행된 이벤트를 받아서 별
 
         // 실제 DB 저장 및 Expo 푸시 알림 발송 로직 실행
         pushNotificationService.send(
-                event.receiver(),
-                event.actor(),
+                event.receiver().getId(),
+                event.actor().getId(),
                 notificationType,
                 message,
                 event.actor().getId()

--- a/src/main/java/com/moongeul/backend/api/notification/service/PushNotificationService.java
+++ b/src/main/java/com/moongeul/backend/api/notification/service/PushNotificationService.java
@@ -59,7 +59,13 @@ public class PushNotificationService {
 
     /* 알림 전송 */
     @Transactional
-    public void send(Member receiver, Member actor, NotificationType notificationType, String message, Long relatedId) {
+    public void send(Long receiverId, Long actorId, NotificationType notificationType, String message, Long relatedId) {
+
+        Member receiver = memberRepository.findById(receiverId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+        Member actor = memberRepository.findById(actorId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
         // 1. 알림 내역 DB 저장
         Notifications notifications = Notifications.builder()
                 .receiver(receiver)
@@ -70,6 +76,12 @@ public class PushNotificationService {
                 .isRead(false)
                 .build();
         notificationRepository.save(notifications);
+
+        // 예외: 푸시알림허용 off일 경우 푸시 전송 X
+        if (!receiver.isPushEnabled()) {
+            log.info("사용자(id: {}, Nickname: {})가 알림을 비활성화하여 푸시를 전송하지 않습니다.", receiver.getId(), receiver.getNickname());
+            return;
+        }
 
         // 2. 수신자의 모든 디바이스 토큰 조회
         List<String> tokenStrings = deviceTokenRepository.findAllByMemberId(receiver.getId())

--- a/src/main/java/com/moongeul/backend/api/setting/controller/SettingController.java
+++ b/src/main/java/com/moongeul/backend/api/setting/controller/SettingController.java
@@ -3,6 +3,7 @@ package com.moongeul.backend.api.setting.controller;
 import com.moongeul.backend.api.setting.dto.AgreeTermsRequestDTO;
 import com.moongeul.backend.api.setting.dto.PrivacyLevelResponseDTO;
 import com.moongeul.backend.api.setting.dto.PrivacyLevelUpdateRequestDTO;
+import com.moongeul.backend.api.setting.dto.PushSettingRequestDTO;
 import com.moongeul.backend.api.setting.service.AgreeTermsSettingService;
 import com.moongeul.backend.api.setting.service.PrivacySettingService;
 import com.moongeul.backend.common.response.ApiResponse;
@@ -82,5 +83,21 @@ public class SettingController {
 
         agreeTermsSettingService.agreeToTerms(userDetails.getUsername(), agreeTermsRequestDTO);
         return ApiResponse.success_only(SuccessStatus.TERMS_AGREE_SUCCESS);
+    }
+
+    @Operation(
+            summary = "푸시 알림 허용 on/off API",
+            description = "푸시 알림 허용 기능을 on/off 합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "푸시 알림 허용 on/off 설정 성공")
+    })
+    @PatchMapping("/push")
+    public ResponseEntity<ApiResponse<Void>> updatePushSetting(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody PushSettingRequestDTO pushSettingRequestDTO) {
+
+        agreeTermsSettingService.updatePushSetting(userDetails.getUsername(), pushSettingRequestDTO.isPushEnabled());
+        return ApiResponse.success_only(SuccessStatus.UPDATE_PUSH_SETTING_SUCCESS);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/setting/dto/PushSettingRequestDTO.java
+++ b/src/main/java/com/moongeul/backend/api/setting/dto/PushSettingRequestDTO.java
@@ -1,0 +1,5 @@
+package com.moongeul.backend.api.setting.dto;
+
+public record PushSettingRequestDTO(
+        boolean isPushEnabled
+) { }

--- a/src/main/java/com/moongeul/backend/api/setting/service/AgreeTermsSettingService.java
+++ b/src/main/java/com/moongeul/backend/api/setting/service/AgreeTermsSettingService.java
@@ -68,6 +68,13 @@ public class AgreeTermsSettingService {
         });
     }
 
+    @Transactional
+    public void updatePushSetting(String email, boolean isPushEnabled) {
+        Member member = getMemberByEmail(email);
+        member.updatePushEnabled(isPushEnabled);
+        log.info("사용자 id: {}, Nickname: {}의 푸시 설정이 {}로 변경되었습니다.", member.getId(), member.getNickname(), isPushEnabled);
+    }
+
     private Member getMemberByEmail(String email) {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -28,9 +28,12 @@ public enum SuccessStatus {
 	UPDATE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 등록 성공"),
 	UPDATE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 이미지 변경 성공"),
 	CHECK_NICKNAME_DUPLICATE_SUCCESS(HttpStatus.OK, "닉네임 중복 체크 성공"),
+
+	/* SETTING */
 	GET_PRIVACY_LEVEL_SUCCESS(HttpStatus.OK, "계정 공개 범위 조회 성공"),
 	UPDATE_PRIVACY_LEVEL_SUCCESS(HttpStatus.OK, "계정 공개 범위 수정 성공"),
 	TERMS_AGREE_SUCCESS(HttpStatus.OK, "약관 동의 성공"),
+	UPDATE_PUSH_SETTING_SUCCESS(HttpStatus.OK, "푸시 알림 허용 on/off 설정 성공"),
 
 	/* READING TASTE */
 	CALCULATE_READING_TASTE_SUCCESS(HttpStatus.OK, "독서 취향 테스트 결과 계산 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #110 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 설정의 '푸시알림허용' on/off 기능을 구현하였습니다.
- 회원가입 시, 푸시알림허용 상태는 true(기본값)입니다.
- 푸시알림허용 off 시, 기기를 통한 푸시 알림은 전송되지 않되 알림 페이지 내역 표시를 위해 알림 데이터는 DB에 저장이 됩니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="701" height="99" alt="image" src="https://github.com/user-attachments/assets/c882d102-5db8-4e11-94a2-00403979a9d7" />