### PR TITLE
[FIX] 카테고리 상세 조회 및 내가 누른 공감 반환 로직 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -192,7 +192,8 @@ public class MemberController {
 
     @Operation(
             summary = "카테고리별 기록 리스트 조회 API (마이페이지 기록장 상세)",
-            description = "특정 카테고리에 작성된 기록들을 조회합니다. userId 쿼리 파라미터가 없으면 본인, 있으면 해당 사용자의 기록을 조회합니다. " +
+            description = "특정 카테고리에 작성된 기록들을 조회합니다. categoryId에 0을 전달하면 모든 카테고리의 기록을 함께 조회합니다. " +
+                    "userId 쿼리 파라미터가 없으면 본인, 있으면 해당 사용자의 기록을 조회합니다. " +
                     "최신순, 오래된순, 평점 높은순, 평점 낮은순으로 정렬할 수 있습니다." +
                     "<br><br>[enum] 정렬 옵션 (sortBy):" +
                     "<br>- LATEST: 최신순 (기본값)" +

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -412,30 +412,47 @@ public class MemberService {
 
         validatePrivacyAccess(currentMember, targetMember);
 
-        // 카테고리 존재 여부 확인
-        Category category = categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage()));
-
-        // 카테고리 소유자 확인
-        if (!category.getMember().getId().equals(targetMember.getId())) {
-            throw new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage());
-        }
-
         Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Post> postPage;
 
-        // 정렬 조건에 따라 조회
-        Page<Post> postPage = switch (sortBy.toUpperCase()) {
-            case "LATEST" ->  // 최신순
-                    postRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
-            case "OLDEST" ->  // 오래된순
-                    postRepository.findByCategoryIdOrderByCreatedAtAsc(categoryId, pageable);
-            case "RATING_HIGH" ->  // 평점 높은순
-                    postRepository.findByCategoryIdOrderByRatingDesc(categoryId, pageable);
-            case "RATING_LOW" ->  // 평점 낮은순
-                    postRepository.findByCategoryIdOrderByRatingAsc(categoryId, pageable);
-            default ->  // 기본값: 최신순
-                    postRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
-        };
+        // categoryId=0 은 전체보기(모든 카테고리 포함)
+        if (Long.valueOf(0L).equals(categoryId)) {
+            postPage = switch (sortBy.toUpperCase()) {
+                case "LATEST" ->
+                        postRepository.findByMemberIdOrderByCreatedAtDesc(targetMember.getId(), pageable);
+                case "OLDEST" ->
+                        postRepository.findByMemberIdOrderByCreatedAtAsc(targetMember.getId(), pageable);
+                case "RATING_HIGH" ->
+                        postRepository.findByMemberIdOrderByRatingDesc(targetMember.getId(), pageable);
+                case "RATING_LOW" ->
+                        postRepository.findByMemberIdOrderByRatingAsc(targetMember.getId(), pageable);
+                default ->
+                        postRepository.findByMemberIdOrderByCreatedAtDesc(targetMember.getId(), pageable);
+            };
+        } else {
+            // 카테고리 존재 여부 확인
+            Category category = categoryRepository.findById(categoryId)
+                    .orElseThrow(() -> new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage()));
+
+            // 카테고리 소유자 확인
+            if (!category.getMember().getId().equals(targetMember.getId())) {
+                throw new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage());
+            }
+
+            // 정렬 조건에 따라 조회
+            postPage = switch (sortBy.toUpperCase()) {
+                case "LATEST" ->  // 최신순
+                        postRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
+                case "OLDEST" ->  // 오래된순
+                        postRepository.findByCategoryIdOrderByCreatedAtAsc(categoryId, pageable);
+                case "RATING_HIGH" ->  // 평점 높은순
+                        postRepository.findByCategoryIdOrderByRatingDesc(categoryId, pageable);
+                case "RATING_LOW" ->  // 평점 낮은순
+                        postRepository.findByCategoryIdOrderByRatingAsc(categoryId, pageable);
+                default ->  // 기본값: 최신순
+                        postRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
+            };
+        }
 
         List<PostDTO> postList = postPage.getContent().stream()
                 .map(this::convertToPostDTO)

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -15,8 +15,11 @@ import com.moongeul.backend.api.notification.repository.DeviceTokenRepository;
 import com.moongeul.backend.api.notification.repository.NotificationRepository;
 import com.moongeul.backend.api.post.dto.CategoryPostListResponseDTO;
 import com.moongeul.backend.api.post.dto.PostDTO;
+import com.moongeul.backend.api.post.entity.LikeType;
+import com.moongeul.backend.api.post.entity.Likes;
 import com.moongeul.backend.api.post.entity.Post;
 import com.moongeul.backend.api.post.entity.Quote;
+import com.moongeul.backend.api.post.repository.LikeRepository;
 import com.moongeul.backend.api.post.repository.PostRepository;
 import com.moongeul.backend.api.post.repository.QuoteRepository;
 import com.moongeul.backend.api.book.entity.Book;
@@ -54,6 +57,7 @@ public class MemberService {
     private final CategoryRepository categoryRepository;
     private final PostRepository postRepository;
     private final QuoteRepository quoteRepository;
+    private final LikeRepository likeRepository;
     private final WithdrawalRepository withdrawalRepository;
     private final NotificationRepository notificationRepository;
     private final AnswerRepository answerRepository;
@@ -455,7 +459,7 @@ public class MemberService {
         }
 
         List<PostDTO> postList = postPage.getContent().stream()
-                .map(this::convertToPostDTO)
+                .map(post -> convertToPostDTO(post, currentMember))
                 .collect(Collectors.toList());
 
         log.info("카테고리별 기록 리스트 조회 완료 - 카테고리 ID: {}, 사용자 ID: {}, 정렬: {}, 페이지: {}, 결과 수: {}",
@@ -499,7 +503,7 @@ public class MemberService {
         };
 
         List<PostDTO> postList = postPage.getContent().stream()
-                .map(this::convertToPostDTO)
+                .map(post -> convertToPostDTO(post, currentMember))
                 .collect(Collectors.toList());
 
         log.info("공감한 기록 리스트 조회 완료 - 사용자 ID: {}, 정렬: {}, 페이지: {}, 결과 수: {}",
@@ -516,7 +520,7 @@ public class MemberService {
     }
 
     // Post를 PostDTO로 변환
-    private PostDTO convertToPostDTO(Post post) {
+    private PostDTO convertToPostDTO(Post post, Member currentMember) {
 
         Book book = post.getBook();
 
@@ -553,6 +557,8 @@ public class MemberService {
                 .helpfulCount(post.getHelpfulCount())
                 .build();
 
+        PostDTO.MyLikesStatus myLikesStatus = convertToMyLikesStatus(currentMember, post.getId());
+
         return PostDTO.builder()
                 .postId(post.getId())
                 .memberInfo(memberInfo)
@@ -564,6 +570,31 @@ public class MemberService {
                 .quotesCnt(quoteDTOList.size())
                 .quotes(quoteDTOList)
                 .likesCnt(likesCnt)
+                .myLikesStatus(myLikesStatus)
+                .build();
+    }
+
+    private PostDTO.MyLikesStatus convertToMyLikesStatus(Member currentMember, Long postId) {
+        if (currentMember == null) {
+            return PostDTO.MyLikesStatus.empty();
+        }
+
+        List<Likes> myLikes = likeRepository.findByPostIdAndMemberId(postId, currentMember.getId());
+
+        if (myLikes.isEmpty()) {
+            return PostDTO.MyLikesStatus.empty();
+        }
+
+        Set<LikeType> myLikesTypes = myLikes.stream()
+                .map(Likes::getLikeType)
+                .collect(Collectors.toSet());
+
+        return PostDTO.MyLikesStatus.builder()
+                .relatableCount(myLikesTypes.contains(LikeType.RELATABLE))
+                .sameTasteCount(myLikesTypes.contains(LikeType.SAME_TASTE))
+                .impressiveExpressionCount(myLikesTypes.contains(LikeType.IMPRESSIVE_EXPRESSION))
+                .wantToReadCount(myLikesTypes.contains(LikeType.WANT_TO_READ))
+                .helpfulCount(myLikesTypes.contains(LikeType.HELPFUL))
                 .build();
     }
 

--- a/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
@@ -85,6 +85,22 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p WHERE p.category.id = :categoryId ORDER BY p.rating ASC, p.createdAt DESC")
     Page<Post> findByCategoryIdOrderByRatingAsc(@Param("categoryId") Long categoryId, Pageable pageable);
 
+    // 사용자의 전체 기록 조회 (최신순)
+    @Query("SELECT p FROM Post p WHERE p.member.id = :memberId ORDER BY p.createdAt DESC")
+    Page<Post> findByMemberIdOrderByCreatedAtDesc(@Param("memberId") Long memberId, Pageable pageable);
+
+    // 사용자의 전체 기록 조회 (오래된순)
+    @Query("SELECT p FROM Post p WHERE p.member.id = :memberId ORDER BY p.createdAt ASC")
+    Page<Post> findByMemberIdOrderByCreatedAtAsc(@Param("memberId") Long memberId, Pageable pageable);
+
+    // 사용자의 전체 기록 조회 (평점 높은순)
+    @Query("SELECT p FROM Post p WHERE p.member.id = :memberId ORDER BY p.rating DESC, p.createdAt DESC")
+    Page<Post> findByMemberIdOrderByRatingDesc(@Param("memberId") Long memberId, Pageable pageable);
+
+    // 사용자의 전체 기록 조회 (평점 낮은순)
+    @Query("SELECT p FROM Post p WHERE p.member.id = :memberId ORDER BY p.rating ASC, p.createdAt DESC")
+    Page<Post> findByMemberIdOrderByRatingAsc(@Param("memberId") Long memberId, Pageable pageable);
+
     // 사용자가 공감한 기록 조회 (최신순)
     @Query(value = "SELECT DISTINCT l.post FROM Likes l " +
             "WHERE l.member.id = :memberId " +


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #111

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기존 카테고리 상세 조회에서 '전체' 를 누른 경우 모든 기록이 나올 수 있도록 수정하였습니다.
- * 조회 조건 : categoryId 필드값에 0 을 넣고 조회

- 마이페이지 내가 공감한 기록 조회 API, 카테고리 상세 리스트 조회 API에서 내가 누른 공감이 무엇인지 나오도록 수정하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 카테고리 상세 조회 API ]
<img width="1418" height="582" alt="image" src="https://github.com/user-attachments/assets/1c7343f7-26ba-450a-b1d7-0289344de985" />

[ 공감 필드 반환 조회 ]
<img width="1418" height="582" alt="image" src="https://github.com/user-attachments/assets/8b164e4f-a5eb-4947-8de0-2f08438d597e" />
