### PR TITLE
[FIX] 알림 페이지 Response 데이터 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/moongeul/backend/api/notification/controller/NotificationController.java
@@ -17,8 +17,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @Tag(name = "Notification", description = "Notification(푸시알람) 관련 API 입니다.")
 @RestController
 @RequiredArgsConstructor
@@ -81,12 +79,12 @@ public class NotificationController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다."),
     })
     @GetMapping
-    public ResponseEntity<ApiResponse<List<NotificationsResponseDTO>>> getNotifications(
+    public ResponseEntity<ApiResponse<NotificationsResponseDTO>> getNotifications(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(required = false, defaultValue = "1") @Min(value = 1, message = "페이지는 1 이상이어야 합니다.(1부터 시작)") Integer page,
             @RequestParam(required = false, defaultValue = "10") @Min(value = 1, message = "한 페이지당 개수는 1 이상이어야 합니다.") Integer size) {
 
-        List<NotificationsResponseDTO> response = notificationService.getNotifications(page, size, userDetails.getUsername());
+        NotificationsResponseDTO response = notificationService.getNotifications(page, size, userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.GET_NOTIFICATIONS_SUCCESS, response);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/notification/dto/NotificationsResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/notification/dto/NotificationsResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -14,14 +15,25 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class NotificationsResponseDTO {
 
-    private Long id; // 알림 ID
+    private Long total; // 전체 검색 결과 수
+    private Integer page; // 현재 페이지
+    private Integer size; // 페이지당 개수
+    private Integer totalPages; // 전체 페이지 수
+    private Boolean isLast; // 마지막 페이지 여부
+    private List<NotificationInfo> data; // 알림 리스트
 
-    private Long relatedId; // 연관된 ID값 (게시글ID, 회원ID 등)
-    private NotificationType notificationType; // 알림 타입 (LIKE, FOLLOW_OPEN ... 등)
+    @Getter
+    @Builder
+    public static class NotificationInfo {
+        private Long id; // 알림 ID
 
-    private String profileImage;
-    private String content;
-    private LocalDateTime created_at;
-    
-    private boolean isRead; // 읽음 처리
+        private Long relatedId; // 연관된 ID값 (게시글ID, 회원ID 등)
+        private NotificationType notificationType; // 알림 타입 (LIKE, FOLLOW_OPEN ... 등)
+
+        private String profileImage;
+        private String content;
+        private LocalDateTime createdAt;
+
+        private boolean isRead; // 읽음 처리
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/moongeul/backend/api/notification/repository/NotificationRepository.java
@@ -2,8 +2,8 @@ package com.moongeul.backend.api.notification.repository;
 
 import com.moongeul.backend.api.notification.entity.NotificationType;
 import com.moongeul.backend.api.notification.entity.Notifications;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notifications, Long> {
 
-    Slice<Notifications> findByReceiverIdOrderByCreatedAtDesc(Long id, Pageable pageable);
+    Page<Notifications> findByReceiverIdOrderByCreatedAtDesc(Long id, Pageable pageable);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Notifications n SET n.isRead = true WHERE n.receiver.id = :receiverId AND n.isRead = false")

--- a/src/main/java/com/moongeul/backend/api/notification/service/NotificationService.java
+++ b/src/main/java/com/moongeul/backend/api/notification/service/NotificationService.java
@@ -9,9 +9,9 @@ import com.moongeul.backend.api.notification.repository.NotificationRepository;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,29 +27,35 @@ public class NotificationService {
 
     /* 알림 내역 전체 조회 */
     @Transactional
-    public List<NotificationsResponseDTO> getNotifications(Integer page, Integer size, String email){
+    public NotificationsResponseDTO getNotifications(Integer page, Integer size, String email) {
         Member member = getMemberByEmail(email);
 
         Pageable pageable = PageRequest.of(page - 1, size);
 
-        Slice<Notifications> notificationsSlice = notificationRepository.findByReceiverIdOrderByCreatedAtDesc(member.getId(), pageable);
+        Page<Notifications> notificationsPage = notificationRepository.findByReceiverIdOrderByCreatedAtDesc(member.getId(), pageable);
 
-        List<NotificationsResponseDTO> response = notificationsSlice.getContent().stream()
-                .map(notification -> NotificationsResponseDTO.builder()
+        List<NotificationsResponseDTO.NotificationInfo> infoList = notificationsPage.getContent().stream()
+                .map(notification -> NotificationsResponseDTO.NotificationInfo.builder()
                         .id(notification.getId())
                         .relatedId(notification.getRelatedId())
                         .notificationType(notification.getType())
-                        .profileImage(notification.getActor() != null ? notification.getActor().getProfileImage() : null) // profile 이미지 null -> 서버공지
+                        .profileImage(notification.getActor() != null ? notification.getActor().getProfileImage() : null)
                         .content(notification.getContent())
-                        .created_at(notification.getCreatedAt())
+                        .createdAt(notification.getCreatedAt())
                         .isRead(notification.isRead())
                         .build())
                 .collect(Collectors.toList());
 
-        // 해당 사용자의 알림 중 읽지 않은(isRead = false) 알림만 모두 true(읽음)로 변경
         notificationRepository.updateIsReadByReceiverId(member.getId());
 
-        return response;
+        return NotificationsResponseDTO.builder()
+                .total(notificationsPage.getTotalElements())
+                .page(page)
+                .size(size)
+                .totalPages(notificationsPage.getTotalPages())
+                .isLast(notificationsPage.isLast())
+                .data(infoList)
+                .build();
     }
 
     @Transactional


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #117

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 알림 페이지 Response 데이터 수정

  - 페이지네이션 데이터 맞추기
  - created_at -> createdAt 필드 네이밍 수정

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[알림 페이지 Response]
<img width="884" height="491" alt="image" src="https://github.com/user-attachments/assets/f612743d-a2bd-413b-a169-73cccebab79a" />