### PR TITLE
[FIX] 랜덤 닉네임 로직, 회원가입 로직 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/moongeul/backend/api/member/controller/MemberController.java
@@ -365,7 +365,7 @@ public class MemberController {
      * */
     @Operation(
             summary = "랜덤 닉네임 재생성 API",
-            description = "랜덤 닉네임을 다시 생성하여 등록하고 바뀐 닉네임을 반환합니다."
+            description = "랜덤 닉네임을 다시 생성하여 반환합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 재생성 성공"),

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -148,15 +148,11 @@ public class MemberService {
 
     // 신규 회원가입 처리 로직 (DB 저장)
     private Member signUp(String socialId, String email, String name, String picture, String socialType) {
-
-        // 랜덤 닉네임 생성
-        String nickname = nicknameGenerator.generateUniqueNickname();
-
         Member newUser = Member.builder()
                 .email(email)
                 .name(name)
                 .profileImage(picture)
-                .nickname(nickname)
+                .nickname(null)
                 .password("OAuth Password") // 임시 패스워드
                 .privacyLevel(PrivacyLevel.PUBLIC) // 기본값: 전체공개
                 .socialId(socialId)
@@ -350,13 +346,10 @@ public class MemberService {
     // 닉네임 재생성
     @Transactional
     public NicknameResponseDTO regenerateNickname(String email) {
-        Member member = getMemberByEmail(email);
+        getMemberByEmail(email);
 
         // 랜덤 닉네임 생성
         String newNickname = nicknameGenerator.generateUniqueNickname();
-
-        // 닉네임 업데이트
-        member.updateNickname(newNickname);
 
         return NicknameResponseDTO.builder()
                 .nickname(newNickname)
@@ -369,6 +362,12 @@ public class MemberService {
         Member member = getMemberByEmail(email);
 
         String nickname = nicknameRequestDTO.getNickname();
+
+        if (Objects.equals(member.getNickname(), nickname)) {
+            return NicknameResponseDTO.builder()
+                    .nickname(nickname)
+                    .build();
+        }
 
         // 닉네임 중복 체크
         if (memberRepository.findByNickname(nickname).isPresent()) {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #119 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 최초 회원가입 시 닉네임이 null값으로 저장되도록 수정했습니다.
- 랜덤 닉네임 재생성 시 닉네임이 저장되지 않도록 수정했습니다.
- 닉네임 등록 API 에서 기존 등록한 닉네임을 다시 넣으면 패스 되도록 수정했습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 기존 닉네임 패스 ]
<img width="1416" height="684" alt="image" src="https://github.com/user-attachments/assets/d4d7630f-3dad-4ee7-aeac-2341ba633063" />
