### PR TITLE
[FEAT] ROLE 승급(GUEST->USER) 로직 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/entity/Member.java
+++ b/src/main/java/com/moongeul/backend/api/member/entity/Member.java
@@ -105,7 +105,12 @@ public class Member extends BaseTimeEntity {
     public void updatePushEnabled(boolean isPushEnabled) {
         this.isPushEnabled = isPushEnabled;
     }
-  
+
+    /**
+     * 푸시 알림 허용 업데이트
+     */
+    public void updateRole(Role role) { this.role = role; }
+
     /**
      * 회원 탈퇴 시 개인정보를 지우는 메서드
      */

--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -23,6 +23,8 @@ import com.moongeul.backend.api.post.repository.LikeRepository;
 import com.moongeul.backend.api.post.repository.PostRepository;
 import com.moongeul.backend.api.post.repository.QuoteRepository;
 import com.moongeul.backend.api.book.entity.Book;
+import com.moongeul.backend.api.setting.entity.Agree;
+import com.moongeul.backend.api.setting.entity.TermsType;
 import com.moongeul.backend.api.story.entity.Story;
 import com.moongeul.backend.api.story.repository.StoryRepository;
 import com.moongeul.backend.api.question.repository.AnswerRepository;
@@ -377,9 +379,33 @@ public class MemberService {
         // 닉네임 업데이트
         member.updateNickname(nickname);
 
+        // ROLE 승급 로직: GUEST->USER
+        // 조건: 약관 동의 + 닉네임 등록을 마쳤다면
+        if (member.getRole() == Role.GUEST && member.getNickname() != null && isAllRequiredTermsAgreed(member)) {
+            member.updateRole(Role.USER);
+        }
+
         return NicknameResponseDTO.builder()
                 .nickname(nickname)
                 .build();
+    }
+
+    // 메서드: 필수 약관 동의 여부 체크
+    private boolean isAllRequiredTermsAgreed(Member member) {
+        List<TermsType> requiredTypes = List.of(TermsType.SERVICE_TERMS_AGREE, TermsType.PRIVACY_POLICY_AGREE);
+        List<Agree> agreeList = agreeRepository.findAllByMember(member);
+
+        int agreedCount = 0; // 필수 약관들이 각각 동의되었는지 체크하기 위한 카운트
+
+        for (Agree agree : agreeList) {
+            TermsType currentType = agree.getTerms().getTermsType();
+
+            // 현재 약관이 필수 약관 리스트에 포함되어 있고, 동의(true) 상태인지 확인
+            if (requiredTypes.contains(currentType) && agree.isAgreed()) {
+                agreedCount++;
+            }
+        }
+        return agreedCount == requiredTypes.size();
     }
 
     // 닉네임 중복 체크

--- a/src/main/java/com/moongeul/backend/api/setting/repository/AgreeRepository.java
+++ b/src/main/java/com/moongeul/backend/api/setting/repository/AgreeRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AgreeRepository extends JpaRepository<Agree, Long> {
@@ -18,4 +19,6 @@ public interface AgreeRepository extends JpaRepository<Agree, Long> {
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Agree a WHERE a.member.id = :memberId")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
+
+    List<Agree> findAllByMember(Member member);
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #123 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 약관동의 + 닉네임 등록 완료 시, 사용자의 ROLE을 GUEST->USER 로 승급하는 로직을 구현하였습니다.
- 화면 프로세스 상, 닉네임 등록 시 조건 여부를 따져 승급하는 로직으로 구현하였습니다.
- 필수 동의 여부 true값에 한하여 약관동의 조건 설정을 하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->