### PR TITLE
[FEAT] 푸시 알림 동의 여부 조회 API & 카테고리명 조회 API 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/category/controller/CategoryController.java
+++ b/src/main/java/com/moongeul/backend/api/category/controller/CategoryController.java
@@ -61,13 +61,13 @@ public class CategoryController {
             description = "카테고리 id 값으로 카테고리명을 조회하는 API 입니다."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카테고리 전체 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "카테고리명은 필수입니다. (category)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카테고리명 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 카테고리를 찾을 수 없습니다."),
     })
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<CategoryResponseDTO>> getCategoryTitle(@RequestParam Long id) {
 
         CategoryResponseDTO response = categoryService.getCategoryTitle(id);
-        return ApiResponse.success(SuccessStatus.GET_CATEGORY_SUCCESS, response);
+        return ApiResponse.success(SuccessStatus.GET_CATEGORY_TITLE_SUCCESS, response);
     }
 }

--- a/src/main/java/com/moongeul/backend/api/category/controller/CategoryController.java
+++ b/src/main/java/com/moongeul/backend/api/category/controller/CategoryController.java
@@ -55,4 +55,19 @@ public class CategoryController {
         CategoryResponseDTO response = categoryService.createCategory(categoryCreateRequestDTO, userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.CREATE_CATEGORY_SUCCESS, response);
     }
+
+    @Operation(
+            summary = "카테고리명 조회 API",
+            description = "카테고리 id 값으로 카테고리명을 조회하는 API 입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카테고리 전체 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "카테고리명은 필수입니다. (category)"),
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<CategoryResponseDTO>> getCategoryTitle(@RequestParam Long id) {
+
+        CategoryResponseDTO response = categoryService.getCategoryTitle(id);
+        return ApiResponse.success(SuccessStatus.GET_CATEGORY_SUCCESS, response);
+    }
 }

--- a/src/main/java/com/moongeul/backend/api/category/service/CategoryService.java
+++ b/src/main/java/com/moongeul/backend/api/category/service/CategoryService.java
@@ -60,6 +60,19 @@ public class CategoryService {
                 .build();
     }
 
+    /* 카테고리명 조회 */
+    @Transactional
+    public CategoryResponseDTO getCategoryTitle(Long id){
+
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.CATEGORY_NOTFOUND_EXCEPTION.getMessage()));
+
+        return CategoryResponseDTO.builder()
+                .categoryId(category.getId())
+                .title(category.getTitle())
+                .build();
+    }
+
     // 사용자 정보 가져오기 메서드
     private Member getMemberByEmail(String email) {
         return memberRepository.findByEmail(email)

--- a/src/main/java/com/moongeul/backend/api/notification/service/NotificationService.java
+++ b/src/main/java/com/moongeul/backend/api/notification/service/NotificationService.java
@@ -71,6 +71,7 @@ public class NotificationService {
                 .build();
     }
 
+
     /*
      * 단순 데이터 불러오기용 코드 메서드 - 코드 깔끔하게 하기용
      */

--- a/src/main/java/com/moongeul/backend/api/setting/controller/SettingController.java
+++ b/src/main/java/com/moongeul/backend/api/setting/controller/SettingController.java
@@ -1,10 +1,10 @@
 package com.moongeul.backend.api.setting.controller;
 
-import com.moongeul.backend.api.post.entity.PostVisibility;
 import com.moongeul.backend.api.setting.dto.*;
 import com.moongeul.backend.api.setting.service.AgreeTermsSettingService;
 import com.moongeul.backend.api.setting.service.NoticeSettingService;
 import com.moongeul.backend.api.setting.service.PrivacySettingService;
+import com.moongeul.backend.api.setting.service.PushSettingService;
 import com.moongeul.backend.common.response.ApiResponse;
 import com.moongeul.backend.common.response.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,6 +27,7 @@ public class SettingController {
     private final PrivacySettingService privacySettingService;
     private final AgreeTermsSettingService agreeTermsSettingService;
     private final NoticeSettingService noticeSettingService;
+    private final PushSettingService pushSettingService;
 
     @Operation(
             summary = "계정 공개 범위 조회 API",
@@ -98,8 +99,23 @@ public class SettingController {
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody PushSettingRequestDTO pushSettingRequestDTO) {
 
-        agreeTermsSettingService.updatePushSetting(userDetails.getUsername(), pushSettingRequestDTO.isPushEnabled());
+        pushSettingService.updatePushSetting(userDetails.getUsername(), pushSettingRequestDTO.isPushEnabled());
         return ApiResponse.success_only(SuccessStatus.UPDATE_PUSH_SETTING_SUCCESS);
+    }
+
+    @Operation(
+            summary = "푸시 알림 동의 여부 조회 API",
+            description = "사용자의 푸시 알림 동의 여부(현 동의/비동의 상태)를 조회하는 API입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "푸시 알림 동의 여부 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다."),
+    })
+    @GetMapping("/push")
+    public ResponseEntity<ApiResponse<PushStatusResponseDTO>> getPushStatus(@AuthenticationPrincipal UserDetails userDetails) {
+
+        PushStatusResponseDTO response = pushSettingService.getPushStatus(userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.GET_NOTIFICATION_AGREE_STATUS_SUCCESS, response);
     }
 
     /*

--- a/src/main/java/com/moongeul/backend/api/setting/dto/PushStatusResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/setting/dto/PushStatusResponseDTO.java
@@ -1,0 +1,15 @@
+package com.moongeul.backend.api.setting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushStatusResponseDTO {
+
+    boolean pushEnabled;
+}

--- a/src/main/java/com/moongeul/backend/api/setting/service/AgreeTermsSettingService.java
+++ b/src/main/java/com/moongeul/backend/api/setting/service/AgreeTermsSettingService.java
@@ -68,13 +68,6 @@ public class AgreeTermsSettingService {
         });
     }
 
-    @Transactional
-    public void updatePushSetting(String email, boolean isPushEnabled) {
-        Member member = getMemberByEmail(email);
-        member.updatePushEnabled(isPushEnabled);
-        log.info("사용자 id: {}, Nickname: {}의 푸시 설정이 {}로 변경되었습니다.", member.getId(), member.getNickname(), isPushEnabled);
-    }
-
     private Member getMemberByEmail(String email) {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));

--- a/src/main/java/com/moongeul/backend/api/setting/service/PushSettingService.java
+++ b/src/main/java/com/moongeul/backend/api/setting/service/PushSettingService.java
@@ -1,0 +1,41 @@
+package com.moongeul.backend.api.setting.service;
+
+import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.member.repository.MemberRepository;
+import com.moongeul.backend.api.setting.dto.PushStatusResponseDTO;
+import com.moongeul.backend.common.exception.NotFoundException;
+import com.moongeul.backend.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PushSettingService {
+
+    private final MemberRepository memberRepository;
+
+    /* 푸시 알림 허용 on/off */
+    @Transactional
+    public void updatePushSetting(String email, boolean isPushEnabled) {
+        Member member = getMemberByEmail(email);
+        member.updatePushEnabled(isPushEnabled);
+        log.info("사용자 id: {}, Nickname: {}의 푸시 설정이 {}로 변경되었습니다.", member.getId(), member.getNickname(), isPushEnabled);
+    }
+
+    /* 푸시 알림 동의 여부 조회 */
+    @Transactional
+    public PushStatusResponseDTO getPushStatus(String email){
+        Member member = getMemberByEmail(email);
+        return PushStatusResponseDTO.builder()
+                .pushEnabled(member.isPushEnabled())
+                .build();
+    }
+
+    private Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    }
+}

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -79,11 +79,13 @@ public enum SuccessStatus {
 
 	/* CATEGORY */
 	GET_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 전체 조회 성공"),
+	GET_CATEGORY_TITLE_SUCCESS(HttpStatus.OK, "카테고명 조회 성공"),
 
 	/* ALARM */
 	REGISTER_DEVICE_TOKEN_SUCCESS(HttpStatus.OK, "사용자 기기 토큰 등록 성공"),
 	GET_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "알림 내역 전체 조회 성공"),
 	GET_UNREAD_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "미확인 알림 존재 여부 조회 성공"),
+	GET_NOTIFICATION_AGREE_STATUS_SUCCESS(HttpStatus.OK, "푸시 알림 동의 여부 조회 성공"),
 
 	/* QUESTION */
 	GET_QUESTION_LIST_SUCCESS(HttpStatus.OK, "질문 리스트 조회 성공"),

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -79,7 +79,7 @@ public enum SuccessStatus {
 
 	/* CATEGORY */
 	GET_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 전체 조회 성공"),
-	GET_CATEGORY_TITLE_SUCCESS(HttpStatus.OK, "카테고명 조회 성공"),
+	GET_CATEGORY_TITLE_SUCCESS(HttpStatus.OK, "카테고리명 조회 성공"),
 
 	/* ALARM */
 	REGISTER_DEVICE_TOKEN_SUCCESS(HttpStatus.OK, "사용자 기기 토큰 등록 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #125 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 푸시 알림 동의 여부를 조회하는 API를 구현하였습니다.
- 카테고리 id값으로 카테고리명을 조회하는 API를 구현하였습니다.
- 푸시 알림 관련 setting API를 PushSettingService 내에서 로직 구현할 수 있게 Service 코드를 생성하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[푸시 알림 동의 여부 조회 API]
<img width="520" height="232" alt="image" src="https://github.com/user-attachments/assets/6bf38189-3ea0-4fa3-a34c-f9574dac5e78" />

[카테고리명 조회 API]
<img width="653" height="781" alt="image" src="https://github.com/user-attachments/assets/3d59138e-a5a9-4563-a654-82453ac8c495" />