### PR TITLE
[FEAT] 사용자가 기록한 책에 대한 기록 리스트 조회 구현

### DIFF
--- a/src/main/java/com/moongeul/backend/api/bookshelf/controller/DoneReadBookshelfController.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/controller/DoneReadBookshelfController.java
@@ -1,5 +1,6 @@
 package com.moongeul.backend.api.bookshelf.controller;
 
+import com.moongeul.backend.api.bookshelf.dto.DoneReadBookPostListResponseDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadCalendarResponseDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadRatingSummaryResponseDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadBookshelfResponseDTO;
@@ -48,6 +49,30 @@ public class DoneReadBookshelfController {
         DoneReadBookshelfResponseDTO doneReadBookshelfResponseDTO =
                 doneReadBookshelfService.getDoneReadBooks(userDetails.getUsername(), userId, page, size);
         return ApiResponse.success(SuccessStatus.GET_DONE_READ_BOOKS_SUCCESS, doneReadBookshelfResponseDTO);
+    }
+
+    @Operation(
+            summary = "읽은 책별 기록 리스트 조회 API",
+            description = "ISBN에 해당하는 도서에 대해 사용자가 작성한 기록 리스트를 최신순으로 조회합니다. " +
+                    "userId 쿼리파라미터가 없으면 본인, 있으면 해당 사용자의 기록을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "읽은 책별 기록 리스트 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 사용자의 정보는 공개되지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자 또는 도서를 찾을 수 없습니다.")
+    })
+    @GetMapping("/{isbn}/posts")
+    public ResponseEntity<ApiResponse<DoneReadBookPostListResponseDTO>> getDoneReadBookPosts(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable String isbn,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(defaultValue = "1") @Min(value = 1, message = "페이지는 1 이상이어야 합니다.") Integer page,
+            @RequestParam(defaultValue = "10") @Min(value = 1, message = "한 페이지당 개수는 1 이상이어야 합니다.") Integer size) {
+
+        DoneReadBookPostListResponseDTO doneReadBookPostListResponseDTO =
+                doneReadBookshelfService.getDoneReadBookPosts(userDetails.getUsername(), userId, isbn, page, size);
+        return ApiResponse.success(SuccessStatus.GET_DONE_READ_BOOK_POSTS_SUCCESS, doneReadBookPostListResponseDTO);
     }
 
     @Operation(

--- a/src/main/java/com/moongeul/backend/api/bookshelf/dto/DoneReadBookPostListResponseDTO.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/dto/DoneReadBookPostListResponseDTO.java
@@ -1,0 +1,25 @@
+package com.moongeul.backend.api.bookshelf.dto;
+
+import com.moongeul.backend.api.post.dto.PostDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DoneReadBookPostListResponseDTO {
+
+    private String title;
+    private String isbn;
+    private long total;
+    private int page;
+    private int size;
+    private int totalPages;
+    private boolean isLast;
+    private List<PostDTO> data;
+}

--- a/src/main/java/com/moongeul/backend/api/bookshelf/service/DoneReadBookshelfService.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/service/DoneReadBookshelfService.java
@@ -1,6 +1,8 @@
 package com.moongeul.backend.api.bookshelf.service;
 
 import com.moongeul.backend.api.book.entity.Book;
+import com.moongeul.backend.api.book.repository.BookRepository;
+import com.moongeul.backend.api.bookshelf.dto.DoneReadBookPostListResponseDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadCalendarDayDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadCalendarResponseDTO;
 import com.moongeul.backend.api.bookshelf.dto.DoneReadBookshelfItemDTO;
@@ -58,6 +60,7 @@ public class DoneReadBookshelfService {
     private final PostRepository postRepository;
     private final QuoteRepository quoteRepository;
     private final LikeRepository likeRepository;
+    private final BookRepository bookRepository;
     private static final String[] RATING_RANGES = {
             "1.0~1.4", "1.5~1.9", "2.0~2.4", "2.5~2.9",
             "3.0~3.4", "3.5~3.9", "4.0~4.4", "4.5~5.0"
@@ -194,6 +197,33 @@ public class DoneReadBookshelfService {
         return DoneReadRatingSummaryResponseDTO.builder()
                 .totalBooks(totalBooks)
                 .data(data)
+                .build();
+    }
+
+    // 읽은 책별 기록 리스트 조회
+    @Transactional(readOnly = true)
+    public DoneReadBookPostListResponseDTO getDoneReadBookPosts(String email, Long userId, String isbn, Integer page, Integer size) {
+        Member currentMember = getCurrentMember(email);
+        Member targetMember = getTargetMember(currentMember, userId);
+        Book book = bookRepository.findByIsbn(isbn)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.BOOK_NOTFOUND_EXCEPTION.getMessage()));
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Post> postPage = postRepository.findByMemberAndBookIsbnOrderByCreatedAtDesc(targetMember, isbn, pageable);
+
+        List<PostDTO> postList = postPage.getContent().stream()
+                .map(post -> convertToPostDTO(post, currentMember))
+                .collect(Collectors.toList());
+
+        return DoneReadBookPostListResponseDTO.builder()
+                .title(book.getTitle())
+                .isbn(book.getIsbn())
+                .total(postPage.getTotalElements())
+                .page(page)
+                .size(size)
+                .totalPages(postPage.getTotalPages())
+                .isLast(postPage.isLast())
+                .data(postList)
                 .build();
     }
 

--- a/src/main/java/com/moongeul/backend/api/bookshelf/service/DoneReadBookshelfService.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/service/DoneReadBookshelfService.java
@@ -17,8 +17,11 @@ import com.moongeul.backend.api.member.repository.FollowRepository;
 import com.moongeul.backend.api.member.repository.MemberRepository;
 import com.moongeul.backend.api.post.dto.CategoryPostListResponseDTO;
 import com.moongeul.backend.api.post.dto.PostDTO;
+import com.moongeul.backend.api.post.entity.LikeType;
+import com.moongeul.backend.api.post.entity.Likes;
 import com.moongeul.backend.api.post.entity.Post;
 import com.moongeul.backend.api.post.entity.Quote;
+import com.moongeul.backend.api.post.repository.LikeRepository;
 import com.moongeul.backend.api.post.repository.PostRepository;
 import com.moongeul.backend.api.post.repository.QuoteRepository;
 import com.moongeul.backend.common.exception.BadRequestException;
@@ -41,6 +44,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -53,6 +57,7 @@ public class DoneReadBookshelfService {
     private final FollowRepository followRepository;
     private final PostRepository postRepository;
     private final QuoteRepository quoteRepository;
+    private final LikeRepository likeRepository;
     private static final String[] RATING_RANGES = {
             "1.0~1.4", "1.5~1.9", "2.0~2.4", "2.5~2.9",
             "3.0~3.4", "3.5~3.9", "4.0~4.4", "4.5~5.0"
@@ -195,20 +200,21 @@ public class DoneReadBookshelfService {
     // 읽은 책 별점 구간 상세 조회
     @Transactional(readOnly = true)
     public CategoryPostListResponseDTO getDoneReadRatingDetail(String email, Long userId, String range, String sortBy, Integer page, Integer size) {
-        Member member = getTargetMember(email, userId);
+        Member currentMember = getCurrentMember(email);
+        Member targetMember = getTargetMember(currentMember, userId);
 
         int rangeIndex = findRangeIndex(range);
         Pageable pageable = PageRequest.of(page - 1, size, resolveSort(sortBy));
 
         Page<Post> postPage = postRepository.findByMemberAndRatingBetween(
-                member,
+                targetMember,
                 RANGE_STARTS[rangeIndex],
                 RANGE_ENDS[rangeIndex],
                 pageable
         );
 
         List<PostDTO> postList = postPage.getContent().stream()
-                .map(this::convertToPostDTO)
+                .map(post -> convertToPostDTO(post, currentMember))
                 .collect(Collectors.toList());
 
         return CategoryPostListResponseDTO.builder()
@@ -236,7 +242,7 @@ public class DoneReadBookshelfService {
                 .build();
     }
 
-    private PostDTO convertToPostDTO(Post post) {
+    private PostDTO convertToPostDTO(Post post, Member currentMember) {
 
         Book book = post.getBook();
 
@@ -273,6 +279,8 @@ public class DoneReadBookshelfService {
                 .helpfulCount(post.getHelpfulCount())
                 .build();
 
+        PostDTO.MyLikesStatus myLikesStatus = convertToMyLikesStatus(currentMember, post.getId());
+
         return PostDTO.builder()
                 .postId(post.getId())
                 .memberInfo(memberInfo)
@@ -284,6 +292,31 @@ public class DoneReadBookshelfService {
                 .quotesCnt(quoteDTOList.size())
                 .quotes(quoteDTOList)
                 .likesCnt(likesCnt)
+                .myLikesStatus(myLikesStatus)
+                .build();
+    }
+
+    private PostDTO.MyLikesStatus convertToMyLikesStatus(Member currentMember, Long postId) {
+        if (currentMember == null) {
+            return PostDTO.MyLikesStatus.empty();
+        }
+
+        List<Likes> myLikes = likeRepository.findByPostIdAndMemberId(postId, currentMember.getId());
+
+        if (myLikes.isEmpty()) {
+            return PostDTO.MyLikesStatus.empty();
+        }
+
+        Set<LikeType> myLikesTypes = myLikes.stream()
+                .map(Likes::getLikeType)
+                .collect(Collectors.toSet());
+
+        return PostDTO.MyLikesStatus.builder()
+                .relatableCount(myLikesTypes.contains(LikeType.RELATABLE))
+                .sameTasteCount(myLikesTypes.contains(LikeType.SAME_TASTE))
+                .impressiveExpressionCount(myLikesTypes.contains(LikeType.IMPRESSIVE_EXPRESSION))
+                .wantToReadCount(myLikesTypes.contains(LikeType.WANT_TO_READ))
+                .helpfulCount(myLikesTypes.contains(LikeType.HELPFUL))
                 .build();
     }
 
@@ -317,9 +350,16 @@ public class DoneReadBookshelfService {
     }
 
     private Member getTargetMember(String email, Long userId) {
-        Member currentMember = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+        Member currentMember = getCurrentMember(email);
+        return getTargetMember(currentMember, userId);
+    }
 
+    private Member getCurrentMember(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    }
+
+    private Member getTargetMember(Member currentMember, Long userId) {
         Member targetMember = (userId == null)
                 ? currentMember
                 : memberRepository.findById(userId)

--- a/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
@@ -144,6 +144,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findByMemberAndRatingBetween(Member member, Double startRating, Double endRating, Pageable pageable);
 
+    @Query("SELECT p FROM Post p WHERE p.member = :member AND p.book.isbn = :isbn ORDER BY p.createdAt DESC")
+    Page<Post> findByMemberAndBookIsbnOrderByCreatedAtDesc(
+            @Param("member") Member member,
+            @Param("isbn") String isbn,
+            Pageable pageable);
+
     // 회원 탈퇴 시 작성한 모든 게시글 삭제
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Post p WHERE p.member.id = :memberId")

--- a/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/moongeul/backend/common/response/SuccessStatus.java
@@ -61,6 +61,7 @@ public enum SuccessStatus {
 	REMOVE_WISH_READ_BOOK_SUCCESS(HttpStatus.OK, "읽고 싶은 책 삭제 성공"),
 	GET_WISH_READ_BOOKS_SUCCESS(HttpStatus.OK, "읽고 싶은 책장 조회 성공"),
 	GET_DONE_READ_BOOKS_SUCCESS(HttpStatus.OK, "읽은 책장 조회 성공"),
+	GET_DONE_READ_BOOK_POSTS_SUCCESS(HttpStatus.OK, "읽은 책별 기록 리스트 조회 성공"),
 	GET_DONE_READ_CALENDAR_SUCCESS(HttpStatus.OK, "읽은 책 캘린더 조회 성공"),
 	GET_DONE_READ_RATING_SUMMARY_SUCCESS(HttpStatus.OK, "읽은 책 별점 요약 조회 성공"),
 	GET_DONE_READ_RATING_DETAIL_SUCCESS(HttpStatus.OK, "읽은 책 별점 구간 상세 조회 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #129 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 사용자가 기록한 책에 대한 기록 리스트 조회를 구현하였습니다.
- userId 파라미터를 사용해서 타 사용자도 조회가 가능하도록 하였습니다.
- 조회 대상자의 공개 범위에 따라 필터링 로직도 추가하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 구현한 API ]
<img width="1433" height="53" alt="image" src="https://github.com/user-attachments/assets/6b28e100-6897-4937-a012-b211b4d73e35" />
