### PR TITLE
[FIX] 스토리 & 질문하기 비회원 조회 가능 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/question/controller/QuestionController.java
+++ b/src/main/java/com/moongeul/backend/api/question/controller/QuestionController.java
@@ -56,7 +56,10 @@ public class QuestionController {
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "10") Integer size) {
 
-        QuestionListResponseDTO questionListResponseDTO = questionService.getQuestionList(page, size, userDetails.getUsername());
+        // 비회원인 경우 "anonymousUser", 회원인 경우 email
+        String username = (userDetails != null) ? userDetails.getUsername() : "anonymousUser";
+
+        QuestionListResponseDTO questionListResponseDTO = questionService.getQuestionList(page, size, username);
         return ApiResponse.success(SuccessStatus.GET_QUESTION_LIST_SUCCESS, questionListResponseDTO);
     }
 

--- a/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/QuestionService.java
@@ -214,8 +214,12 @@ public class QuestionService {
                 .map(Member::getProfileImage)
                 .collect(Collectors.toList());
 
-        // 내가 작성한 질문인지 확인
-        boolean isMyArticle = question.getMember().getEmail().equals(email);
+
+        boolean isMyArticle = false;
+        if(!(email == null || "anonymousUser".equals(email))){
+            // 내가 작성한 질문인지 확인
+            isMyArticle = question.getMember().getEmail().equals(email);
+        }
 
         return QuestionDTO.builder()
                 .questionId(question.getId())

--- a/src/main/java/com/moongeul/backend/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/moongeul/backend/common/config/security/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v2/member/google/login", "/api/v2/member/kakao/login", "/api/v2/member/reissue-token").permitAll()
                         .requestMatchers("/api/v2/reading-taste", "/api/v2/reading-taste/total-count").permitAll()
                         .requestMatchers("/api/v2/book/bestseller").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/v2/post/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v2/post/**", "/api/v2/story/**", "/api/v2/question/list").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v2/bookshelf/done-read", "/api/v2/bookshelf/done-read/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v2/member/user-info", "/api/v2/member/post-stats", "/api/v2/member/post-stats/**", "/api/v2/member/liked-posts", "/api/v2/member/question-list").permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #137 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 홈 페이지의 스토리 및 질문하기 리스트를 비회원도 조회 가능하도록 수정하였습니다.
- 스토리 -> 상세 조회 가능 (PUBLIC의 스토리만 조회됨)
- 질문 -> 상세 조회 불가능 (로그인 후 사용 띄우면 될 것 같습니다!)
- (태근 파트)코드 변경: 질문하기 service 로직의 email 부분을, anonymous 처리하여 isMyArticle을 false 처리하도록 코드 구현하였습니다!

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="1049" height="503" alt="image" src="https://github.com/user-attachments/assets/5d18dd6c-cf66-4e00-aeed-29e497c5f4cf" />
