### PR TITLE
[FIX] 게시글 삭제 시 스토리&읽은책장 연동 관련 데이터 무결성 에러 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/book/dto/ReviewItemDTO.java
+++ b/src/main/java/com/moongeul/backend/api/book/dto/ReviewItemDTO.java
@@ -17,6 +17,7 @@ import java.util.List;
 @AllArgsConstructor
 public class ReviewItemDTO {
     private Long postId; // 게시글 ID
+    private Long memberId; // 사용자 ID
     private String nickname; // 사용자 닉네임
     private ReadingTasteType readingTasteType; // 독서 취향
     private String profileImage; // 사용자 프로필 이미지

--- a/src/main/java/com/moongeul/backend/api/book/service/ReviewService.java
+++ b/src/main/java/com/moongeul/backend/api/book/service/ReviewService.java
@@ -77,6 +77,7 @@ public class ReviewService {
 
         return ReviewItemDTO.builder()
                 .postId(post.getId())
+                .memberId(post.getMember().getId())
                 .nickname(post.getMember().getNickname())
                 .readingTasteType(post.getMember().getReadingTasteType())
                 .profileImage(post.getMember().getProfileImage())

--- a/src/main/java/com/moongeul/backend/api/bookshelf/repository/DoneReadBookshelfRepository.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/repository/DoneReadBookshelfRepository.java
@@ -3,6 +3,7 @@ package com.moongeul.backend.api.bookshelf.repository;
 import com.moongeul.backend.api.book.entity.Book;
 import com.moongeul.backend.api.bookshelf.entity.DoneReadBookshelf;
 import com.moongeul.backend.api.member.entity.Member;
+import com.moongeul.backend.api.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,4 +26,7 @@ public interface DoneReadBookshelfRepository extends JpaRepository<DoneReadBooks
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM DoneReadBookshelf d WHERE d.member.id = :memberId")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
+
+    // 연동된 게시글 삭제 시 책장의 책도 삭제
+    void deleteByArticle(Post article);
 }

--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -16,6 +16,8 @@ import com.moongeul.backend.api.post.repository.LikeRepository;
 import com.moongeul.backend.api.post.repository.PostRepository;
 import com.moongeul.backend.api.post.repository.QuoteRepository;
 import com.moongeul.backend.api.post.util.WritingGuideGenerator;
+import com.moongeul.backend.api.story.entity.Story;
+import com.moongeul.backend.api.story.repository.StoryRepository;
 import com.moongeul.backend.common.annotation.Timer;
 import com.moongeul.backend.common.exception.NotFoundException;
 import com.moongeul.backend.common.exception.UnauthorizedException;
@@ -47,8 +49,9 @@ public class PostService {
     private final CategoryRepository categoryRepository;
     private final QuoteRepository quoteRepository;
     private final DoneReadBookshelfRepository doneReadBookshelfRepository;
-    private final BookshelfCalculator bookshelfCalculator;
+    private final StoryRepository storyRepository;
 
+    private final BookshelfCalculator bookshelfCalculator;
     private final NotificationTriggerService notificationTriggerService;
     private final WritingGuideGenerator writingGuideGenerator;
     
@@ -338,6 +341,8 @@ public class PostService {
 
         Post post = getPost(postId);
         Book book = post.getBook();
+        Story story = storyRepository.findByPostId(postId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.STORY_NOTFOUND_EXCEPTION.getMessage()));
 
         // 예외처리: 수정하는 사람과 게시글 주인이 같은지 확인 (본인의 게시글인지)
         if (!post.getMember().getEmail().equals(email)) {
@@ -346,6 +351,12 @@ public class PostService {
 
         // 인상깊은구절 일괄 삭제
         quoteRepository.deleteAllByPostId(postId);
+
+        // 연동된 Story 삭제
+        storyRepository.delete(story);
+
+        // 읽은 책장 데이터 삭제
+        doneReadBookshelfRepository.deleteByArticle(post);
 
         // 게시글 삭제
         postRepository.delete(post);

--- a/src/main/java/com/moongeul/backend/api/story/repository/StoryRepository.java
+++ b/src/main/java/com/moongeul/backend/api/story/repository/StoryRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface StoryRepository extends JpaRepository<Story, Long> {
 
@@ -47,4 +48,7 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
             "WHERE s.member.email = :email " +
             "ORDER BY s.createdAt DESC")
     Page<Story> findAllMyStories(@Param("email") String email, Pageable pageable);
+
+    // postId로 스토리 조회
+    Optional<Story> findByPostId(Long postId);
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #139 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 게시글 삭제 시, 스토리와 읽은 책장 데이터의 postId 연동 때문에 데이터 무결성 문제 발생으로 삭제가 되지 않는 오류를 수정하였습니다.
- 게시글 삭제 시, 해당 게시글과 연결된 스토리 및 읽은 책장의 책 데이터를 모두 삭제 합니다.

+) 추가: (프론트 요청) review 조회 시 memberId 필드를 추가하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[게시글 삭제]
<img width="654" height="192" alt="image" src="https://github.com/user-attachments/assets/cf17cc24-b372-4db1-9977-5782589f561f" />
[책 리뷰 조회 시 memberId 추가]
<img width="883" height="497" alt="image" src="https://github.com/user-attachments/assets/a39bd2f1-10ca-4274-9713-c3bffb415d30" />
