### PR TITLE
[FIX] 게시글 삭제 기능 오류 + 검색/책 상세 페이지 비회원 조회 가능하게 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/bookshelf/entity/DoneReadBookshelf.java
+++ b/src/main/java/com/moongeul/backend/api/bookshelf/entity/DoneReadBookshelf.java
@@ -47,5 +47,13 @@ public class DoneReadBookshelf extends BaseTimeEntity {
         this.height = height;
         this.postCount = this.postCount + 1;
     }
+
+    // 게시글 삭제 시 이전 기록으로 갱신 (게시글 개수 감소 및 데이터 재설정)
+    public void updateWithPreviousPost(Post previousPost, Float weight, Float height) {
+        this.article = previousPost;
+        this.weight = weight;
+        this.height = height;
+        this.postCount = Math.max(0, this.postCount - 1); // 개수 감소 (음수 방지)
+    }
 }
 

--- a/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
@@ -159,4 +159,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Post p WHERE p.member.id = :memberId")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
+
+    // 해당 사용자와 책으로 작성된 게시글 중 삭제될 게시글을 제외하고 생성일자 역순으로 첫번째 데이터 가져오기
+    // findFirst: 하나만 가져올 건데(LIMIT 1)
+    // ByMemberAndBook: 조건은 해당 멤버와 책으로 하고
+    // AndIdNot: 지금 삭제할 게시글ID는 제외하고 찾고(AND id <> ?)
+    // OrderByCreatedAtDesc: 가장 최근에 쓴 순대로 정렬해서 가져와
+    Optional<Post> findFirstByMemberAndBookAndIdNotOrderByCreatedAtDesc(Member member, Book book, Long postId);
 }

--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -16,7 +16,6 @@ import com.moongeul.backend.api.post.repository.LikeRepository;
 import com.moongeul.backend.api.post.repository.PostRepository;
 import com.moongeul.backend.api.post.repository.QuoteRepository;
 import com.moongeul.backend.api.post.util.WritingGuideGenerator;
-import com.moongeul.backend.api.story.entity.Story;
 import com.moongeul.backend.api.story.repository.StoryRepository;
 import com.moongeul.backend.common.annotation.Timer;
 import com.moongeul.backend.common.exception.NotFoundException;
@@ -341,8 +340,6 @@ public class PostService {
 
         Post post = getPost(postId);
         Book book = post.getBook();
-        Story story = storyRepository.findByPostId(postId)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.STORY_NOTFOUND_EXCEPTION.getMessage()));
 
         // 예외처리: 수정하는 사람과 게시글 주인이 같은지 확인 (본인의 게시글인지)
         if (!post.getMember().getEmail().equals(email)) {
@@ -352,18 +349,43 @@ public class PostService {
         // 인상깊은구절 일괄 삭제
         quoteRepository.deleteAllByPostId(postId);
 
-        // 연동된 Story 삭제
-        storyRepository.delete(story);
+        // 3. 연동된 Story 삭제 (있을 때만 삭제하도록 수정)
+        storyRepository.findByPostId(postId).ifPresent(storyRepository::delete);
 
-        // 읽은 책장 데이터 삭제
-        doneReadBookshelfRepository.deleteByArticle(post);
+        // 읽은 책장 데이터 갱신 로직
+        updateBookshelfAfterDeletion(post.getMember(), book, post);
 
         // 게시글 삭제
         postRepository.delete(post);
 
         updateBookRatingStats(book);
     }
-    
+
+    // 게시글 삭제 시 읽은 책장의 참조 게시글(article_id)을 이전 기록으로 갱신하는 메서드
+    private void updateBookshelfAfterDeletion(Member member, Book book, Post deletedPost) {
+        doneReadBookshelfRepository.findByMemberAndBook(member, book).ifPresent(bookshelf -> {
+            // 만약 삭제하려는 게시글이 현재 책장에서 참조하고 있는 게시글(최신글)이라면
+            if (bookshelf.getArticle().equals(deletedPost)) {
+                // 해당 책과 사용자의 게시글 중, 삭제될 게시글을 제외하고 가장 최근 게시글을 찾음
+                Optional<Post> previousPostOpt = postRepository.findFirstByMemberAndBookAndIdNotOrderByCreatedAtDesc(
+                        member, book, deletedPost.getId());
+
+                if (previousPostOpt.isPresent()) {
+                    // 이전 기록이 있다면 그것으로 갱신
+                    Post previousPost = previousPostOpt.get();
+
+                    Float weight = bookshelfCalculator.calculateWeight(previousPost.getPage());
+                    Float height = bookshelfCalculator.calculateHeight(previousPost.getRating());
+
+                    bookshelf.updateWithPreviousPost(previousPost, weight, height);
+
+                } else {
+                    // 더 이상 남은 기록이 없다면 책장 데이터 자체를 삭제 (선택 사항)
+                    doneReadBookshelfRepository.delete(bookshelf);
+                }
+            }
+        });
+    }
     
     // 새로운 인상깊은구절 저장
     private void saveQuotes(PostRequestDTO postRequestDTO, Post post){

--- a/src/main/java/com/moongeul/backend/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/moongeul/backend/common/config/security/SecurityConfig.java
@@ -39,7 +39,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/v2/reading-taste", "/api/v2/reading-taste/total-count").permitAll()
                         .requestMatchers("/api/v2/book/bestseller").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v2/book/bestseller/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/v2/post/**", "/api/v2/story/**", "/api/v2/question/list").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v2/post/**", "/api/v2/story/**", "/api/v2/question/list").permitAll() // 홈: 게시글, 스토리, 질문 페이지
+                        .requestMatchers(HttpMethod.GET, "/api/v2/book/user/search", "/api/v2/book/{isbn}").permitAll() // 도서 검색 + 책 상세 페이지
                         .requestMatchers(HttpMethod.GET, "/api/v2/bookshelf/done-read", "/api/v2/bookshelf/done-read/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v2/member/user-info", "/api/v2/member/post-stats", "/api/v2/member/post-stats/**", "/api/v2/member/liked-posts", "/api/v2/member/question-list").permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #143 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기존, 스토리 Not Found 에러  발생으로 인한 게시글 삭제 기능 오류를 수정하였습니다.
- 추가로, 같은 책에 대한 게시글 추가 시 '읽은 책' DB와 연결된 ArticleId가 기존 갱신되는 로직으로 구현되어 있어, 게시글 삭제 시 단순 연동 삭제가 불가능했습니다.
- 이에 따라, 삭제 시 이전의 다른 기록이 있는지의 여부에 따라 ArticleId 값을 갱신 or 없다면 아예 삭제하는 방식으로 로직을 구현하였습니다.
- 검색/책 상세 페이지 비회원 조회 가능하게 수정하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->