### PR TITLE
[FIX] 책 상세 리뷰 비회원 조회 & moongeul에서 많이 기록된 책 로직 오류 수정

### DIFF
--- a/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/PostRepository.java
@@ -42,12 +42,14 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p WHERE p.book = :book ORDER BY p.createdAt DESC")
     Page<Post> findByBookOrderByCreatedAtDesc(@Param("book") Book book, Pageable pageable);
 
-    // 전체 공개 기록 기준으로 가장 많이 기록된 책 ISBN 조회
-    @Query("SELECT p.book.isbn FROM Post p " +
-            "WHERE p.postVisibility = 'PUBLIC' " +
-            "GROUP BY p.book.isbn " +
-            "ORDER BY COUNT(p) DESC, MAX(p.createdAt) DESC")
-    List<String> findMostRecordedPublicBookIsbn(Pageable pageable);
+    // 전체 공개 기록 기준으로 가장 많이 기록된(동률 시 최신순) 책 ISBN 하나 조회
+    @Query(value = "SELECT p.book_isbn " +
+            "FROM post p " +
+            "WHERE p.post_visibility = 'PUBLIC' " +
+            "GROUP BY p.book_isbn " +
+            "ORDER BY COUNT(p.id) DESC, MAX(p.created_at) DESC " +
+            "LIMIT 1", nativeQuery = true)
+    Optional<String> findMostRecordedBookIsbn();
 
     // 특정 ISBN의 전체 공개 게시글 중 가장 최근 기록 조회
     Optional<Post> findFirstByBookIsbnAndPostVisibilityOrderByCreatedAtDesc(

--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -29,7 +29,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
@@ -471,14 +470,11 @@ public class PostService {
     // 가장 많이 기록된 책 조회
     @Transactional(readOnly = true)
     public MostRecordedBookResponseDTO getMostRecordedBook() {
-        List<String> mostRecordedBookIsbnList = postRepository.findMostRecordedPublicBookIsbn(PageRequest.of(0, 1));
+        // 가장 많이 기록된(동률 시 최신순) 책의 ISBN을 하나 가져옴
+        String mostRecordedBookIsbn = postRepository.findMostRecordedBookIsbn()
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.MOST_RECORDED_BOOK_NOT_FOUND_EXCEPTION.getMessage()));
 
-        if (mostRecordedBookIsbnList.isEmpty()) {
-            throw new NotFoundException(ErrorStatus.MOST_RECORDED_BOOK_NOT_FOUND_EXCEPTION.getMessage());
-        }
-
-        String mostRecordedBookIsbn = mostRecordedBookIsbnList.get(0);
-
+        // 해당 ISBN을 가진 PUBLIC 포스트 중 가장 최신 포스트를 조회
         Post post = postRepository.findFirstByBookIsbnAndPostVisibilityOrderByCreatedAtDesc(
                         mostRecordedBookIsbn,
                         PostVisibility.PUBLIC
@@ -499,7 +495,7 @@ public class PostService {
                 .build();
     }
     
-    // 주간 추천 기록 조회
+    // 월간 추천 기록 조회 (주간 -> 월간 임시 변경)
     @Transactional(readOnly = true)
     public WeeklyRecommendationResponseDTO getWeeklyRecommendation(String email) {
         Member member = getMemberByEmail(email);
@@ -509,16 +505,17 @@ public class PostService {
             throw new NotFoundException(ErrorStatus.USER_READING_TASTE_NOT_FOUND_EXCEPTION.getMessage());
         }
 
-        // 이번 주 월요일 00:00:00부터 오늘까지 계산
+        // 이번 달 1일 00:00:00 계산
         LocalDate today = LocalDate.now();
-        LocalDate thisWeekMonday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        LocalDateTime weekStart = thisWeekMonday.atStartOfDay();
+        // 해당 월의 1일로 설정
+        LocalDate firstDayOfMonth = today.with(TemporalAdjusters.firstDayOfMonth());
+        LocalDateTime monthStart = firstDayOfMonth.atStartOfDay();
 
         // 같은 취향 사용자들의 기록 중 이번 주(월요일~오늘) 가장 공감을 많이 받은 기록 조회
         // 전체 기록을 조회한 후 정렬하여 가장 공감을 많이 받은 기록 선택
         List<Post> recommendedPosts = postRepository.findWeeklyRecommendationByReadingTasteType(
                 member.getReadingTasteType(),
-                weekStart
+                monthStart
         );
 
         // 추천 기록이 없으면 예외 처리

--- a/src/main/java/com/moongeul/backend/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/moongeul/backend/common/config/security/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v2/book/bestseller").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v2/book/bestseller/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v2/post/**", "/api/v2/story/**", "/api/v2/question/list").permitAll() // 홈: 게시글, 스토리, 질문 페이지
-                        .requestMatchers(HttpMethod.GET, "/api/v2/book/user/search", "/api/v2/book/{isbn}").permitAll() // 도서 검색 + 책 상세 페이지
+                        .requestMatchers(HttpMethod.GET, "/api/v2/book/user/search", "/api/v2/book/{isbn}", "/api/v2/book/review/{isbn}").permitAll() // 도서 검색 + 책 상세 페이지 + 리뷰
                         .requestMatchers(HttpMethod.GET, "/api/v2/bookshelf/done-read", "/api/v2/bookshelf/done-read/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v2/member/user-info", "/api/v2/member/post-stats", "/api/v2/member/post-stats/**", "/api/v2/member/liked-posts", "/api/v2/member/question-list").permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #145 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 책 상세 페이지의 리뷰를 비회원도 조회 가능하도록 변경하였습니다.
- moongeul에서 많이 기록된 책 로직 오류를 수정하였습니다. (로직: 전체 공개 기록 기준으로 가장 많이 기록된(동률 시 최신순) 책의 기록을 반환)
- '취향이 닮은 사람들의 인기책'을 주간 계산에서 월간 계산으로 임시 변경하였습니다. (서비스 초기 데이터가 많지 않아 자주 비어서)

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="369" height="701" alt="image" src="https://github.com/user-attachments/assets/b330ec1f-cc71-41a5-ad8d-607f31828a24" />