### PR TITLE
[FIX] 읽을 책 -> 읽은 책 자동 전환 기능 & 기타 수정사항 반영

### DIFF
--- a/src/main/java/com/moongeul/backend/api/post/service/PostService.java
+++ b/src/main/java/com/moongeul/backend/api/post/service/PostService.java
@@ -4,6 +4,7 @@ import com.moongeul.backend.api.book.entity.Book;
 import com.moongeul.backend.api.book.repository.BookRepository;
 import com.moongeul.backend.api.bookshelf.entity.DoneReadBookshelf;
 import com.moongeul.backend.api.bookshelf.repository.DoneReadBookshelfRepository;
+import com.moongeul.backend.api.bookshelf.repository.WishReadBookshelfRepository;
 import com.moongeul.backend.api.bookshelf.util.BookshelfCalculator;
 import com.moongeul.backend.api.member.entity.Member;
 import com.moongeul.backend.api.member.repository.MemberRepository;
@@ -47,6 +48,7 @@ public class PostService {
     private final CategoryRepository categoryRepository;
     private final QuoteRepository quoteRepository;
     private final DoneReadBookshelfRepository doneReadBookshelfRepository;
+    private final WishReadBookshelfRepository wishReadBookshelfRepository;
     private final StoryRepository storyRepository;
 
     private final BookshelfCalculator bookshelfCalculator;
@@ -88,6 +90,10 @@ public class PostService {
         // 기존 읽은 책이 있는지 확인
         DoneReadBookshelf doneReadBookshelf = doneReadBookshelfRepository.findByMemberAndBook(member, book)
                 .orElse(null);
+
+        // 읽을 책 책장에 있으면 제거 (읽은 책으로 이동)
+        wishReadBookshelfRepository.findByMemberAndBook(member, book)
+                .ifPresent(wishReadBookshelfRepository::delete);
 
         if (doneReadBookshelf != null) {
             // 기존 책장이 있으면 업데이트 (가장 최근 게시글로 변경, 게시글 개수 증가)


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #149 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 읽을 책 -> 읽은 책 자동 전환 기능: 게시글(post) 등록 시 (읽을 책장에 있을 경우) 읽은 책으로 자동 전환하였습니다.
- 인상깊은구절 페이지 (-) 마이너스 방지: DTO 단에서 막는 코드를 사전 구현하였습니다.
- 탈퇴하기 기능 오류: 문제 없이 동작하는 것을 확인했습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="669" height="203" alt="image" src="https://github.com/user-attachments/assets/df5b12d5-e92b-40a1-aea8-d91325de1642" />