### PR TITLE
[FIX] 댓글에서 상대 프로필 클릭 시 무한 로딩 & 탈퇴하기 기능 오류 체크

### DIFF
--- a/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/moongeul/backend/api/member/service/MemberService.java
@@ -294,8 +294,15 @@ public class MemberService {
         doneReadBookshelfRepository.deleteAllByMemberId(member.getId());
         wishReadBookshelfRepository.deleteAllByMemberId(member.getId());
 
+        // [스토리] 삭제
+        storyRepository.deleteAllByMemberId(member.getId());
+
+        // [좋아요] 삭제
+        likeRepository.deleteAllByMemberId(member.getId()); // 내가 누른 좋아요
+        likeRepository.deleteByPostMemberId(member.getId()); // 내가 쓴 글에 눌린 좋아요
+
         // [게시글 & 인용구]
-        quoteRepository.deleteAllByMemberId(member.getId()); // Post 이전에 삭제
+        quoteRepository.deleteAllByMemberId(member.getId()); // Post 이전에 삭제(quote)
         postRepository.deleteAllByMemberId(member.getId());
 
         // [카테고리] Post가 모두 삭제된 후 삭제 가능

--- a/src/main/java/com/moongeul/backend/api/post/repository/LikeRepository.java
+++ b/src/main/java/com/moongeul/backend/api/post/repository/LikeRepository.java
@@ -3,6 +3,9 @@ package com.moongeul.backend.api.post.repository;
 import com.moongeul.backend.api.post.entity.LikeType;
 import com.moongeul.backend.api.post.entity.Likes;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +20,15 @@ public interface LikeRepository extends JpaRepository<Likes, Long> {
 
     // 특정 게시글의 모든 공감 조회
     List<Likes> findByPostId(Long postId);
+
+    // 회원 탈퇴 시 삭제
+    // 1. 내가 누른 좋아요 삭제 (member_id 기준)
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Likes l WHERE l.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
+
+    // 2. 내가 쓴 게시글에 대한 타인의 좋아요 삭제 (post의 member_id 기준)
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Likes l WHERE l.post.id IN (SELECT p.id FROM Post p WHERE p.member.id = :memberId)")
+    void deleteByPostMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/moongeul/backend/api/question/dto/AnswerDTO.java
+++ b/src/main/java/com/moongeul/backend/api/question/dto/AnswerDTO.java
@@ -26,6 +26,7 @@ public class AnswerDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MemberInfo {
+        private Long memberId;
         private String profileImage; // 프로필 이미지
         private String nickname; // 닉네임
         private ReadingTasteType readingTasteType; // 독서 취향 유형

--- a/src/main/java/com/moongeul/backend/api/question/service/AnswerService.java
+++ b/src/main/java/com/moongeul/backend/api/question/service/AnswerService.java
@@ -151,6 +151,7 @@ public class AnswerService {
                 .createdAt(answer.getCreatedAt())
                 .myAnswer(isMyAnswer)
                 .memberInfo(AnswerDTO.MemberInfo.builder()
+                        .memberId(member.getId())
                         .profileImage(member.getProfileImage())
                         .nickname(member.getNickname())
                         .readingTasteType(member.getReadingTasteType())

--- a/src/main/java/com/moongeul/backend/api/story/repository/StoryRepository.java
+++ b/src/main/java/com/moongeul/backend/api/story/repository/StoryRepository.java
@@ -4,6 +4,7 @@ import com.moongeul.backend.api.story.entity.Story;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -51,4 +52,9 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
 
     // postId로 스토리 조회
     Optional<Story> findByPostId(Long postId);
+
+    // 회원 탈퇴 시 작성한 모든 스토리 삭제
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Story s WHERE s.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #151 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
댓글에서 상대 프로필 클릭 시 무한 로딩 & 탈퇴하기 기능 오류 체크
1. 댓글에서 상대 프로필 클릭 시 무한 로딩
  - question 댓글의 memberInfo에 memberId 추가하였습니다.
2. 탈퇴하기 기능 오류 체크
  - 이전 테스트에서 서비스 이용 데이터(스토리, 게시글, 좋아요 등)가 없는 계정으로 테스트하여 탈퇴하기가 통과되었습니다. 현 작업에서 테스트 데이터가 충분한 계정으로 테스트하였고, 오류를 발견하여 해결하였습니다.
  - 해결 1) 탈퇴 대상의 게시글(post)에 연동된 스토리(story) 정보 일괄 삭제
  - 해결 2) 게시글(post)과 사용자(member)와 연관된 좋아요(likes) 데이터 일괄 삭제

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="1173" height="495" alt="image" src="https://github.com/user-attachments/assets/1b96f351-2e11-4c33-a977-6e4c132be188" />
<img width="545" height="176" alt="image" src="https://github.com/user-attachments/assets/4e4aad17-455d-4af6-80d6-72f1d16683a7" />